### PR TITLE
chore: trigger release builds only on tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  create:
+  push: # trigger whenever a new version tag gets pushed https://github.community/t/how-to-run-github-actions-workflow-only-for-new-tags/16075/23
     tags: [ v* ]
 
 jobs:


### PR DESCRIPTION
create.tags appears not to be an official webhook payload for actions,
hence triggering release builds also for branches.

This fixes the draft releases seen on branch builds, e.g. https://github.com/meshcloud/unipipe-service-broker/releases/tag/untagged-d906f47b6d384dd8fc3d