### PR TITLE
chore(build): improve docker-build-push workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: lowercase repository name # docker needs a lowercase name, see https://github.community/t/additional-function-s-lowercase-uppercase/140632
+      run: |
+        echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
     - uses: docker/build-push-action@v1
       with:
         registry: ghcr.io
-        repository: ${{github.repository}}
-        username: ${{ github.actor }}
-        password: ${{ secrets.CR_PAT }} 
+        repository: ${{ env.REPO }}
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
         tag_with_ref: true
         push: ${{ startsWith(github.ref, 'refs/tags/') }}
         add_git_labels: true


### PR DESCRIPTION
- use GITHUB_TOKEN instead of a personal access token
  this is now supported by GitHub and recommended over PATs
- enforce lowercase for repo name so that private forks can more easily
  publish their own builds of unipipe-service-broker to ghcr.io registry