### PR TITLE
Feature/refactor repositories

### DIFF
--- a/src/main/kotlin/io/meshcloud/dockerosb/model/Status.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/model/Status.kt
@@ -1,6 +1,16 @@
 package io.meshcloud.dockerosb.model
 
+import org.springframework.cloud.servicebroker.model.instance.OperationState
+
 data class Status(
     var status: String = "",
     var description: String = ""
-)
+) {
+  fun toOperationState(): OperationState {
+    return when (status) {
+      "succeeded" -> OperationState.SUCCEEDED
+      "failed" -> OperationState.FAILED
+      else -> OperationState.IN_PROGRESS
+    }
+  }
+}

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/CatalogRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/CatalogRepository.kt
@@ -1,0 +1,32 @@
+package io.meshcloud.dockerosb.persistence
+
+import mu.KotlinLogging
+import org.springframework.cloud.servicebroker.model.catalog.Catalog
+import org.springframework.cloud.servicebroker.model.catalog.ServiceDefinition
+
+private val log = KotlinLogging.logger { }
+
+class CatalogRepository(
+    private val yamlHandler: YamlHandler,
+    private val gitHandler: GitHandler
+) {
+
+  fun getCatalog(): Catalog {
+    val statusYml = gitHandler.fileInRepo("catalog.yml")
+
+    if (!statusYml.isFile) {
+      log.error { "Could not read catalog.yml file from '${statusYml.absolutePath}'. Will start with an empty catalog." }
+      return Catalog.builder().build()
+    }
+
+    val catalog = yamlHandler.readObject(statusYml, YamlCatalog::class.java)
+
+    return Catalog.builder()
+        .serviceDefinitions(catalog.services)
+        .build()
+  }
+
+  private class YamlCatalog(
+      val services: List<ServiceDefinition>
+  )
+}

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/CatalogRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/CatalogRepository.kt
@@ -12,14 +12,14 @@ class CatalogRepository(
 ) {
 
   fun getCatalog(): Catalog {
-    val statusYml = gitHandler.fileInRepo("catalog.yml")
+    val catalogYml = gitHandler.fileInRepo("catalog.yml")
 
-    if (!statusYml.isFile) {
-      log.error { "Could not read catalog.yml file from '${statusYml.absolutePath}'. Will start with an empty catalog." }
+    if (!catalogYml.isFile) {
+      log.error { "Could not read catalog.yml file from '${catalogYml.absolutePath}'. Will start with an empty catalog." }
       return Catalog.builder().build()
     }
 
-    val catalog = yamlHandler.readObject(statusYml, YamlCatalog::class.java)
+    val catalog = yamlHandler.readObject(catalogYml, YamlCatalog::class.java)
 
     return Catalog.builder()
         .serviceDefinitions(catalog.services)

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandler.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandler.kt
@@ -2,6 +2,9 @@ package io.meshcloud.dockerosb.persistence
 
 import java.io.File
 
+/**
+ * Note: consumers should use this only via a [GitOperationContext]
+ */
 interface GitHandler {
 
   fun pullFastForwardOnly()

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
@@ -15,6 +15,9 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 private val log = KotlinLogging.logger {}
 
+/**
+ * Note: consumers should use this only via a [GitOperationContext]
+ */
 @Service
 class GitHandlerService(
     private val gitConfig: GitConfig

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
@@ -1,47 +1,9 @@
 package io.meshcloud.dockerosb.persistence
 
-import org.springframework.stereotype.Service
 import java.io.Closeable
-import java.util.concurrent.locks.ReentrantLock
-
-/**
- * Design: Provides a simple means to synchronize/serialize all git repository interactions.
- * Only one [GitOperationContext] can be active at a single time.
- *
- * Typical git interactions should be fairly short-lived and therefore queuing them should be fine.
- * Of course this limits the theoretical throughput of the system. However a typical unipipe deployment does not have to
- * handle a lot of requests per second so this should not be much of a problem. If it becomes a problem, we can optimize
- * this further at the cost of some additional complexity (e.g. separate read/write paths).
- */
-@Service
-class GitOperationContextFactory(
-    private val gitHandler: GitHandler,
-    private val yamlHandler: YamlHandler
-) {
-
-  // we have exactly one git operation that may be active at any time
-  private val lock = ReentrantLock(true)
-
-  fun acquireContext(): GitOperationContext {
-    assert(!lock.isHeldByCurrentThread) {
-      "Tried to acquire a ${GitOperationContext::class.simpleName} while the current thread has already acquired one. This is a coding error as it could lead to deadlock/double-release situations."
-    }
-
-    lock.lock()
-
-    return GitOperationContext(
-        yamlHandler,
-        gitHandler
-    ) { instance -> releaseContext(instance) }
-  }
-
-  fun releaseContext(context: GitOperationContext) {
-    lock.unlock()
-  }
-}
 
 class GitOperationContext(
-    val yamlHandler: YamlHandler,
+    private val yamlHandler: YamlHandler,
     private val gitHandler: GitHandler,
     private val onClose: (GitOperationContext) -> Unit
 ) : Closeable {

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
@@ -85,6 +85,9 @@ class GitOperationContext(
     return ServiceInstanceBindingRepository(yamlHandler, gitHandler)
   }
 
+  fun buildCatalogRepository(): CatalogRepository {
+    return CatalogRepository(yamlHandler, gitHandler)
+  }
 }
 
 

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
@@ -42,12 +42,39 @@ class GitOperationContextFactory(
 
 class GitOperationContext(
     val yamlHandler: YamlHandler,
-    val gitHandler: GitHandler,
+    private val gitHandler: GitHandler,
     private val onClose: (GitOperationContext) -> Unit
 ) : Closeable {
 
   override fun close() {
     onClose(this)
+  }
+
+  /**
+   * Consumers should use this to signal that they wish to operate on the latest remote changes available.
+   * See [GitHandler.pullFastForwardOnly]
+   *
+   * Design:
+   * Only local commits are batched and periodically synced to the remote, see notes on [ScheduledPushHandler].
+   * Remote commits on the other hand are not periodically pulled (unless they are synced as part of a scheduled push as described above).
+   * The reason we do _not_ pull periodically is that we assume unipipe pipelines are in "steady" state most of the time,
+   * meaning all services are provisioned and there's no activity ongoing. Periodically pulling would therefore be a waste
+   * of resources both locally as well as on the remote repository as the vast majority of pulls would contain no changes.
+   *
+   * Instead we use this method to signal that we want to fetch any changes from the remote on an "on-demand" basis.
+   * This is roughly equivalent to a `git pull --ff-only` and should typically be a quick and inexpensive operation.
+   *
+   * TODO: we may want to implement rate limiting etc. in here
+   */
+  fun attemptToRefreshRemoteChanges(){
+    gitHandler.pullFastForwardOnly()
+  }
+
+  /**
+   * See [GitHandler.synchronizeWithRemoteRepository]
+   */
+  fun synchronizeWithRemoteRepository(){
+    gitHandler.synchronizeWithRemoteRepository()
   }
 
   fun buildServiceInstanceRepository(): ServiceInstanceRepository {

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
@@ -49,5 +49,11 @@ class GitOperationContext(
   override fun close() {
     onClose(this)
   }
+
+  fun buildServiceInstanceRepository(): ServiceInstanceRepository {
+    return ServiceInstanceRepository(yamlHandler, gitHandler)
+  }
+
 }
+
 

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContext.kt
@@ -54,6 +54,10 @@ class GitOperationContext(
     return ServiceInstanceRepository(yamlHandler, gitHandler)
   }
 
+  fun buildServiceInstanceBindingRepository(): ServiceInstanceBindingRepository {
+    return ServiceInstanceBindingRepository(yamlHandler, gitHandler)
+  }
+
 }
 
 

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContextFactory.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitOperationContextFactory.kt
@@ -1,0 +1,40 @@
+package io.meshcloud.dockerosb.persistence
+
+import org.springframework.stereotype.Service
+import java.util.concurrent.locks.ReentrantLock
+
+/**
+ * Design: Provides a simple means to synchronize/serialize all git repository interactions.
+ * Only one [GitOperationContext] can be active at a single time.
+ *
+ * Typical git interactions should be fairly short-lived and therefore queuing them should be fine.
+ * Of course this limits the theoretical throughput of the system. However a typical unipipe deployment does not have to
+ * handle a lot of requests per second so this should not be much of a problem. If it becomes a problem, we can optimize
+ * this further at the cost of some additional complexity (e.g. separate read/write paths).
+ */
+@Service
+class GitOperationContextFactory(
+    private val gitHandler: GitHandler,
+    private val yamlHandler: YamlHandler
+) {
+
+  // we have exactly one git operation that may be active at any time
+  private val lock = ReentrantLock(true)
+
+  fun acquireContext(): GitOperationContext {
+    assert(!lock.isHeldByCurrentThread) {
+      "Tried to acquire a ${GitOperationContext::class.simpleName} while the current thread has already acquired one. This is a coding error as it could lead to deadlock/double-release situations."
+    }
+
+    lock.lock()
+
+    return GitOperationContext(
+        yamlHandler,
+        gitHandler
+    ) { instance -> releaseContext(instance) }
+  }
+
+  fun releaseContext(context: GitOperationContext) {
+    lock.unlock()
+  }
+}

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/ScheduledPushHandler.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/ScheduledPushHandler.kt
@@ -35,7 +35,7 @@ class ScheduledPushHandler(val gitOperationContextFactory: GitOperationContextFa
   )
   fun pushTask() {
     gitOperationContextFactory.acquireContext().use { context ->
-      context.gitHandler.synchronizeWithRemoteRepository()
+      context.synchronizeWithRemoteRepository()
     }
   }
 }

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceBindingRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceBindingRepository.kt
@@ -1,0 +1,99 @@
+package io.meshcloud.dockerosb.persistence
+
+import com.fasterxml.jackson.core.type.TypeReference
+import io.meshcloud.dockerosb.model.ServiceBinding
+import io.meshcloud.dockerosb.model.Status
+import org.springframework.cloud.servicebroker.model.instance.OperationState
+import java.io.File
+import java.util.HashMap
+
+class ServiceInstanceBindingRepository(private val yamlHandler: YamlHandler, private val gitHandler: GitHandler) {
+  fun createBinding(serviceBinding: ServiceBinding) {
+    val bindingYml = bindingYmlFile(serviceBinding.serviceInstanceId, serviceBinding.bindingId)
+
+    yamlHandler.writeObject(
+        objectToWrite = serviceBinding,
+        file = bindingYml
+    )
+
+    gitHandler.commitAllChanges(
+        commitMessage = "Created Service binding ${serviceBinding.bindingId}"
+    )
+  }
+
+  fun getServiceBindingStatus(serviceInstanceId: String, bindingId: String): Status {
+    val statusYml = statusYmlFile(serviceInstanceId, bindingId)
+
+    return when (statusYml.exists()) {
+      true -> yamlHandler.readObject(statusYml, Status::class.java)
+      else -> Status(
+          status = OperationState.IN_PROGRESS.value,
+          description = "preparing binding"
+      )
+    }
+  }
+
+  fun getServiceBindingCredentials(serviceInstanceId: String, bindingId: String): Map<String, Any> {
+    val credentialsYml = credentialsYmlFile(serviceInstanceId, bindingId)
+
+    return when (credentialsYml.exists()) {
+      true -> {
+        val typeRef = object : TypeReference<HashMap<String, Any>>() {}
+        yamlHandler.readObject(credentialsYml, typeRef)
+      }
+      else -> emptyMap()
+    }
+  }
+
+  fun tryGetServiceBinding(serviceInstanceId: String, bindingId: String): ServiceBinding? {
+    val bindingYml = bindingYmlFile(serviceInstanceId, bindingId)
+
+    if (!bindingYml.exists()) {
+      return null
+    }
+
+    return yamlHandler.readObject(bindingYml, ServiceBinding::class.java)
+  }
+
+  fun deleteServiceInstanceBinding(binding: ServiceBinding) {
+    binding.deleted = true
+    val bindingYml = bindingYmlFile(binding.serviceInstanceId, binding.bindingId)
+    yamlHandler.writeObject(
+        objectToWrite = binding,
+        file = bindingYml
+    )
+
+    val statusYml = statusYmlFile(binding.serviceInstanceId, binding.bindingId)
+    val status = Status("in progress", "preparing binding deletion")
+    yamlHandler.writeObject(
+        objectToWrite = status,
+        file = statusYml
+    )
+
+    gitHandler.commitAllChanges(
+        commitMessage = "Marked Service binding ${binding.bindingId} as deleted."
+    )
+  }
+
+  private fun bindingYmlFile(serviceInstanceId: String, bindingId: String): File {
+    val bindingYmlPath = bindingFolderPath(serviceInstanceId, bindingId) + "/binding.yml"
+
+    return gitHandler.fileInRepo(bindingYmlPath)
+  }
+
+  private fun statusYmlFile(serviceInstanceId: String, bindingId: String): File {
+    val statusYmlPath = bindingFolderPath(serviceInstanceId, bindingId) + "/status.yml"
+
+    return gitHandler.fileInRepo(statusYmlPath)
+  }
+
+  private fun credentialsYmlFile(serviceInstanceId: String, bindingId: String): File {
+    val credentialsYmlPath = bindingFolderPath(serviceInstanceId, bindingId) + "/credentials.yml"
+
+    return gitHandler.fileInRepo(credentialsYmlPath)
+  }
+
+  private fun bindingFolderPath(serviceInstanceId: String, bindingId: String): String {
+    return "instances/${serviceInstanceId}/bindings/${bindingId}"
+  }
+}

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
@@ -1,0 +1,82 @@
+package io.meshcloud.dockerosb.persistence
+
+import io.meshcloud.dockerosb.model.ServiceInstance
+import io.meshcloud.dockerosb.model.Status
+import org.springframework.cloud.servicebroker.model.instance.OperationState
+import java.io.File
+
+class ServiceInstanceRepository(private val yamlHandler: YamlHandler, private val gitHandler: GitHandler) {
+  fun createServiceInstance(serviceInstance: ServiceInstance) {
+    val serviceInstanceId = serviceInstance.serviceInstanceId
+
+    val instanceYml = serviceInstanceYmlFile(serviceInstanceId)
+
+    yamlHandler.writeObject(
+        objectToWrite = serviceInstance,
+        file = instanceYml
+    )
+    gitHandler.commitAllChanges(
+        commitMessage = "Created Service instance $serviceInstanceId"
+    )
+  }
+
+  fun deleteServiceInstance(serviceInstance: ServiceInstance) {
+    val serviceInstanceId = serviceInstance.serviceInstanceId
+
+    val instanceYml = serviceInstanceYmlFile(serviceInstanceId)
+    serviceInstance.deleted = true
+    yamlHandler.writeObject(
+        objectToWrite = serviceInstance,
+        file = instanceYml
+    )
+
+    val statusYml = serviceInstanceStatusYmlFile(serviceInstanceId)
+    val status = Status("in progress", "preparing service deletion")
+    yamlHandler.writeObject(
+        objectToWrite = status,
+        file = statusYml
+    )
+
+    gitHandler.commitAllChanges(commitMessage = "Marked Service instance $serviceInstanceId as deleted.")
+  }
+
+  fun getServiceInstance(serviceInstanceId: String): ServiceInstance {
+    val instanceYml = serviceInstanceYmlFile(serviceInstanceId)
+
+    return yamlHandler.readObject(instanceYml, ServiceInstance::class.java)
+  }
+
+  fun tryGetServiceInstance(serviceInstanceId: String): ServiceInstance? {
+    val instanceYml = serviceInstanceYmlFile(serviceInstanceId)
+
+    if (!instanceYml.exists()) {
+      return null
+    }
+
+    return yamlHandler.readObject(instanceYml, ServiceInstance::class.java)
+  }
+
+  private fun serviceInstanceYmlFile(serviceInstanceId: String): File {
+    val instanceYmlPath = "instances/$serviceInstanceId/instance.yml"
+
+    return gitHandler.fileInRepo(instanceYmlPath)
+  }
+
+  fun getServiceInstanceStatus(serviceInstanceId: String): Status {
+    val statusYml = serviceInstanceStatusYmlFile(serviceInstanceId)
+
+    return when (statusYml.exists()) {
+      true -> yamlHandler.readObject(statusYml, Status::class.java)
+      else -> Status(
+          status = OperationState.IN_PROGRESS.value,
+          description = "preparing deployment"
+      )
+    }
+  }
+
+  private fun serviceInstanceStatusYmlFile(serviceInstanceId: String): File {
+    val instanceYmlPath = "instances/$serviceInstanceId/status.yml"
+
+    return gitHandler.fileInRepo(instanceYmlPath)
+  }
+}

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
@@ -56,11 +56,6 @@ class ServiceInstanceRepository(private val yamlHandler: YamlHandler, private va
     return yamlHandler.readObject(instanceYml, ServiceInstance::class.java)
   }
 
-  private fun serviceInstanceYmlFile(serviceInstanceId: String): File {
-    val instanceYmlPath = "instances/$serviceInstanceId/instance.yml"
-
-    return gitHandler.fileInRepo(instanceYmlPath)
-  }
 
   fun getServiceInstanceStatus(serviceInstanceId: String): Status {
     val statusYml = serviceInstanceStatusYmlFile(serviceInstanceId)
@@ -74,9 +69,20 @@ class ServiceInstanceRepository(private val yamlHandler: YamlHandler, private va
     }
   }
 
-  private fun serviceInstanceStatusYmlFile(serviceInstanceId: String): File {
-    val instanceYmlPath = "instances/$serviceInstanceId/status.yml"
+  private fun serviceInstanceYmlFile(serviceInstanceId: String): File {
+    val instanceYmlPath = instanceFolderPath(serviceInstanceId) + "/instance.yml"
 
     return gitHandler.fileInRepo(instanceYmlPath)
   }
+
+  private fun serviceInstanceStatusYmlFile(serviceInstanceId: String): File {
+    val instanceYmlPath = instanceFolderPath(serviceInstanceId) + "/status.yml"
+
+    return gitHandler.fileInRepo(instanceYmlPath)
+  }
+
+  private fun instanceFolderPath(serviceInstanceId: String): String {
+    return "instances/$serviceInstanceId"
+  }
 }
+

--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/YamlHandler.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/YamlHandler.kt
@@ -9,6 +9,9 @@ import org.springframework.stereotype.Service
 import java.io.File
 import java.io.FileWriter
 
+/**
+ * Note: consumers should use this only via a [GitOperationContext]
+ */
 @Service
 class YamlHandler {
 

--- a/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.kt
@@ -77,7 +77,7 @@ class GenericServiceInstanceBindingService(
 
   override fun getLastOperation(request: GetLastServiceBindingOperationRequest): Mono<GetLastServiceBindingOperationResponse> {
     gitContextFactory.acquireContext().use { context ->
-      context.gitHandler.pullFastForwardOnly()
+      context.attemptToRefreshRemoteChanges()
 
       val repository = context.buildServiceInstanceBindingRepository()
 
@@ -94,7 +94,7 @@ class GenericServiceInstanceBindingService(
 
   override fun getServiceInstanceBinding(request: GetServiceInstanceBindingRequest): Mono<GetServiceInstanceBindingResponse> {
     gitContextFactory.acquireContext().use { context ->
-      context.gitHandler.pullFastForwardOnly()
+      context.attemptToRefreshRemoteChanges()
 
       val repository = context.buildServiceInstanceBindingRepository()
 

--- a/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceService.kt
@@ -61,6 +61,9 @@ class GenericServiceInstanceService(
 
   override fun getLastOperation(request: GetLastServiceOperationRequest): Mono<GetLastServiceOperationResponse> {
     gitContextFactory.acquireContext().use { context ->
+
+      context.attemptToRefreshRemoteChanges()
+
       val catalog = catalogService.getCatalogInternal()
 
       if (catalog.isSynchronousService(request.serviceDefinitionId)) {

--- a/src/test/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceServiceTest.kt
+++ b/src/test/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceServiceTest.kt
@@ -123,13 +123,14 @@ class GenericServiceInstanceServiceTest {
   fun `instance yaml is correctly updated after delete Service Instance`() {
     val sut = makeSut()
 
+    val serviceInstanceId = copyInstanceYmlToRepo()
+
     val request = DeleteServiceInstanceRequest
         .builder()
-        .serviceInstanceId("test-567")
+        .serviceInstanceId(serviceInstanceId)
         .serviceDefinitionId("my-def")
         .build()
 
-    copyInstanceYmlToRepo(request.serviceInstanceId)
 
     val response = sut.deleteServiceInstance(request).block()!!
 
@@ -146,13 +147,14 @@ class GenericServiceInstanceServiceTest {
   fun `status is correctly updated after delete Service Instance`() {
     val sut = makeSut()
 
+    val serviceInstanceId = copyInstanceYmlToRepo()
+
     val request = DeleteServiceInstanceRequest
         .builder()
-        .serviceInstanceId("test-567")
+        .serviceInstanceId(serviceInstanceId)
         .serviceDefinitionId("my-def")
         .build()
 
-    copyInstanceYmlToRepo(request.serviceInstanceId)
 
     sut.deleteServiceInstance(request).block()
 
@@ -163,11 +165,15 @@ class GenericServiceInstanceServiceTest {
     assertEquals("preparing service deletion", updatedStatus.description)
   }
 
-  private fun copyInstanceYmlToRepo(serviceInstanceId: String) {
+  private fun copyInstanceYmlToRepo(): String {
+    val serviceInstanceId = "e4bd6a78-7e05-4d5a-97b8-f8c5d1c710ab"
     val instanceYmlPath = "${fixture.localGitPath}/instances/$serviceInstanceId/instance.yml"
 
     val existingInstanceYml = File("src/test/resources/expected_instance.yml")
     val instanceYmlInRepo = File(instanceYmlPath)
+
     FileUtils.copyFile(existingInstanceYml, instanceYmlInRepo)
+
+    return serviceInstanceId
   }
 }


### PR DESCRIPTION
this PR removes all direct yaml/git handling from spring-osb services into dedicated repository classes. This is not only cleaner wrt. SRP but also better enforces the unit of work pattern in `GitOperationContext`, making it more difficult to write incorrect code that bypasses this transactional layer for coordinating concurrent git operations.