### PR TITLE
fix(git): correctly initialize git repo with configured remote branch

### DIFF
--- a/src/test/kotlin/io/meshcloud/dockerosb/RemoteGitFixture.kt
+++ b/src/test/kotlin/io/meshcloud/dockerosb/RemoteGitFixture.kt
@@ -6,11 +6,13 @@ import java.io.File
 import java.nio.file.Path
 
 class RemoteGitFixture(
-    private val repositoryRootPath: String
+    private val repositoryRootPath: String,
+    branch: String = "master"
 ) {
   // init remote git
   private val git = Git.init()
       .setDirectory(File(repositoryRootPath))
+      .setInitialBranch(branch)
       .call()
 
 

--- a/src/test/kotlin/io/meshcloud/dockerosb/ServiceBrokerFixture.kt
+++ b/src/test/kotlin/io/meshcloud/dockerosb/ServiceBrokerFixture.kt
@@ -5,7 +5,6 @@ import io.meshcloud.dockerosb.config.GitConfig
 import io.meshcloud.dockerosb.persistence.GitOperationContextFactory
 import io.meshcloud.dockerosb.persistence.GitHandlerService
 import io.meshcloud.dockerosb.persistence.YamlHandler
-import io.meshcloud.dockerosb.service.GenericCatalogService
 import org.junit.rules.TemporaryFolder
 import java.io.Closeable
 
@@ -31,7 +30,7 @@ class ServiceBrokerFixture(catalogPath: String) : Closeable {
 
   // note: it's important we place the initializer before the constructors below since we need to seed the repo with a
   // catalog before we access it internally
-  val remote = RemoteGitFixture(remoteGitPath).apply {
+  val remote = RemoteGitFixture(remoteGitPath, ).apply {
     initWithCatalog(catalogPath)
   }
 
@@ -40,8 +39,6 @@ class ServiceBrokerFixture(catalogPath: String) : Closeable {
   val gitHandler = GitHandlerService(gitConfig)
 
   val contextFactory = GitOperationContextFactory(gitHandler, yamlHandler)
-
-  val catalogService = GenericCatalogService(contextFactory)
 
   val builder = TestDataBuilder(catalogPath, yamlHandler)
 

--- a/src/test/kotlin/io/meshcloud/dockerosb/service/Git.kt
+++ b/src/test/kotlin/io/meshcloud/dockerosb/service/Git.kt
@@ -1,0 +1,43 @@
+package io.meshcloud.dockerosb.service
+
+import io.meshcloud.dockerosb.RemoteGitFixture
+import io.meshcloud.dockerosb.config.GitConfig
+import io.meshcloud.dockerosb.persistence.GitHandlerService
+import org.eclipse.jgit.revwalk.RevCommit
+import org.junit.Assert
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GitHandlerServiceTest {
+
+  @Test
+  fun `can use main as a remote branch`() {
+    val tmp = TemporaryFolder().apply {
+      create()
+    }
+
+    try {
+      val localGitPath = tmp.newFolder("git-local").absolutePath
+      val remoteGitPath = tmp.newFolder("git-remote").absolutePath
+
+      val gitConfig = GitConfig(
+          localPath = localGitPath,
+          remote = remoteGitPath,
+          remoteBranch = "main",
+          sshKey = null,
+          username = null,
+          password = null
+      )
+
+      RemoteGitFixture(remoteGitPath, gitConfig.remoteBranch).apply {
+        initWithCatalog("src/test/resources/catalog.yml")
+      }
+
+      val sut = GitHandlerService(gitConfig)
+
+      Assert.assertNotEquals(emptyList<RevCommit>(), sut.getLog());
+    } finally {
+      tmp.delete()
+    }
+  }
+}


### PR DESCRIPTION
Fixes an issue when a remote branch other than "master" was configured
(e.g. "main"). Unipipe now first fetches the remote branch and then
attempts to create or checkout a local tracking branch.

Fixes #40