### PR TITLE
feat: add a unipipe upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ The `unipipe` cli is the swiss army knife in the UniPipe universe. Use it to:
 
 # How to install unipipe cli
 
-Run the command below depending on your operating system. Check the content of the file to be sure that the install script is safe.
+Run the command below depending on your operating system.
+
+## Binary distribution
+
+Check the content of the file to be sure that the install script is safe.
 
 **Linux**
 
@@ -30,6 +34,17 @@ curl -sf -L https://raw.githubusercontent.com/meshcloud/unipipe-service-broker/m
 ```
 curl -sf -L https://raw.githubusercontent.com/meshcloud/unipipe-service-broker/master/cli/install.sh | sh
 ```
+
+## Deno install
+
+If you already have a [deno runtime](https://deno.land/#installation) installed on your system, you can install and upgrade unipipe cli comfortably via:
+
+```bash
+deno install --unstable --allow-read --allow-write --allow-env --allow-net --allow-run https://raw.githubusercontent.com/meshcloud/unipipe-service-broker/master/cli/unipipe/main.ts
+```
+
+Use the builtin `unipipe upgrade` command to switch to a particular official version of the cli.
+
 
 # How to deploy UniPipe Service Broker on Azure with terraform
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,12 +2,12 @@
 
 > There are certain parts about the process that could be automated better, pull requests are welcome.
 
-1. Pick a new version number according to [semver](https://semver.org/). 
+1. Pick a new version number according to [semver](https://semver.org/).
    Note that we consider the configuration parameters part of unipipe service broker's "API".
    Note that we consider the commands and output part of unipipe cli's "API".
   
 2. Update the version number in these places:
-    - `cli/main.ts`
+    - `cli/info.ts`
 
 3. Update `CHANGELOG.md`. We follow the guidelines from
    [Keep a Changelog][keep-a-changelog]. It's recommended to add changes for the next version in a vNext section already together with pull requests, as this will make releasing a lot easier.

--- a/cli/build.sh
+++ b/cli/build.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-deno_flags="--unstable --allow-read --allow-write --allow-env"
+deno_flags=$(deno run flags.ts --quiet)
 
 mkdir -p bin
 

--- a/cli/flags.ts
+++ b/cli/flags.ts
@@ -1,0 +1,2 @@
+import { FLAGS } from './unipipe/info.ts';
+console.log(FLAGS);

--- a/cli/test/parse-yaml.ts
+++ b/cli/test/parse-yaml.ts
@@ -1,8 +1,8 @@
 // a KISS deno script to parse yaml and output it as json
 // this allows us to test a) yaml is valid and b) access properties using jq
 
-import * as yaml from 'https://deno.land/std@0.99.0/encoding/yaml.ts';
-import * as util from 'https://deno.land/std@0.99.0/io/util.ts';
+import * as yaml from 'https://deno.land/std@0.115.1/encoding/yaml.ts';
+import * as util from 'https://deno.land/std@0.115.1/io/util.ts';
 
 const stdin = new TextDecoder().decode(
   await util.readAll(Deno.stdin),

--- a/cli/unipipe/commands/upgrade.ts
+++ b/cli/unipipe/commands/upgrade.ts
@@ -1,0 +1,35 @@
+import { path, Command, GithubProvider, UpgradeCommand } from '../deps.ts';
+import { GITHUB_REPO, FLAGS, VERSION } from '../info.ts';
+
+export function registerUpgradeCmd(program: Command) {
+  const denoExecutable = Deno.execPath();
+  const isRuntime = path.basename(denoExecutable) === "deno"; // simple and stupid, but avoids recursively invoking ourselves!
+
+  if (!isRuntime) {
+    const msg = `Upgrade is only supported when unipipe cli was installed via "deno install".`;
+    program
+      .command("upgrade")
+      .description(msg)
+      .action(() => {
+        console.error(
+          msg
+          + `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n`
+          + `\nTry installing via:\n`
+          + `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`
+
+        );
+        Deno.exit(1);
+      });
+  }
+  else {
+    program.command(
+      "upgrade",
+      new UpgradeCommand({
+        args: FLAGS.split(" "),
+        provider: [
+          new GithubProvider({ repository: GITHUB_REPO }),
+        ],
+      }),
+    );
+  }
+}

--- a/cli/unipipe/deps.ts
+++ b/cli/unipipe/deps.ts
@@ -3,16 +3,15 @@
 // this is a deno best practice https://deno.land/manual@v1.7.4/examples/manage_dependencies
 // for  discussion of the performance implications (and why this doesn't matter much for this _app_) see https://github.com/denoland/deno/issues/6194
 
-export * as path from "https://deno.land/std@0.99.0/path/mod.ts";
-export * as yaml from "https://deno.land/std@0.99.0/encoding/yaml.ts";
-export { v4 as uuid } from "https://deno.land/std@0.99.0/uuid/mod.ts";
-
-export * as colors from 'https://deno.land/std@0.90.0/fmt/colors.ts';
+export * as path from "https://deno.land/std@0.115.1/path/mod.ts";
+export * as yaml from "https://deno.land/std@0.115.1/encoding/yaml.ts";
+export { v4 as uuid } from "https://deno.land/std@0.115.1/uuid/mod.ts";
+export * as colors from 'https://deno.land/std@0.115.1/fmt/colors.ts';
 
 // note: it's a bit ugly that we have to foray into the private parts of the stdlib, but otherwise we can't configure
 // the options we need
-export { Type as YamlType } from "https://deno.land/std@0.99.0/encoding/_yaml/type.ts";
-export { Schema as YamlSchema } from "https://deno.land/std@0.99.0/encoding/_yaml/schema.ts";
+export { Type as YamlType } from "https://deno.land/std@0.115.1/encoding/_yaml/type.ts";
+export { Schema as YamlSchema } from "https://deno.land/std@0.115.1/encoding/_yaml/schema.ts";
 
 /**
  * 3rd party deps
@@ -21,8 +20,9 @@ export {
   Command,
   Type,
   EnumType,
-  CompletionsCommand
-} from "https://deno.land/x/cliffy@v0.19.2/command/mod.ts";
-export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.19.2/command/mod.ts";
-export { Table } from "https://deno.land/x/cliffy@v0.19.2/table/mod.ts";
-export { Input, Select } from "https://deno.land/x/cliffy@v0.19.2/prompt/mod.ts";
+  CompletionsCommand,
+} from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
+export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
+export { UpgradeCommand, GithubProvider } from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
+export { Table } from "https://deno.land/x/cliffy@v0.20.1/table/mod.ts";
+export { Input, Select } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";

--- a/cli/unipipe/dev_deps.ts
+++ b/cli/unipipe/dev_deps.ts
@@ -1,1 +1,1 @@
-export { assertEquals } from "https://deno.land/std@0.99.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.115.1/testing/asserts.ts";

--- a/cli/unipipe/info.ts
+++ b/cli/unipipe/info.ts
@@ -1,0 +1,3 @@
+export const VERSION = "1.2.4";
+export const FLAGS = "--unstable --allow-read --allow-write --allow-env --allow-net --allow-run";
+export const GITHUB_REPO = "meshcloud/unipipe-service-broker";

--- a/cli/unipipe/main.ts
+++ b/cli/unipipe/main.ts
@@ -3,11 +3,13 @@ import { registerListCmd } from './commands/list.ts';
 import { registerShowCmd } from './commands/show.ts';
 import { registerTransformCmd } from './commands/transform.ts';
 import { registerUpdateCmd } from './commands/update.ts';
+import { registerUpgradeCmd } from './commands/upgrade.ts';
 import { Command, CompletionsCommand } from './deps.ts';
+import { VERSION } from './info.ts';
 
 const program = new Command()
   .name("unipipe")
-  .version("1.2.2")
+  .version(VERSION)
   .description("UniPipe CLI - supercharge your GitOps OSB service pipelines");
 
 program
@@ -18,6 +20,7 @@ registerShowCmd(program);
 registerTransformCmd(program);
 registerUpdateCmd(program);
 registerGenerateCmd(program);
+registerUpgradeCmd(program);
 
 const hasArgs = Deno.args.length > 0;
 if (hasArgs)

--- a/cli/unipipe/unipipe.sh
+++ b/cli/unipipe/unipipe.sh
@@ -3,4 +3,5 @@
 set -o errexit
 set -o nounset
 
-deno run --allow-read --allow-write --allow-env --unstable "$(dirname "$0")"/main.ts "$@"
+deno_flags=$(deno run flags.ts --quiet)
+deno run $deno_flags "$(dirname "$0")"/main.ts "$@"


### PR DESCRIPTION
- the command uses cliffy's upgrade command to allow a user to install/upgrade
to a particular version of unipipe cli
- unify the handling of deno flags so we don't miss out updating them
- update cliffy and deno std lib dependencies