### PR TITLE
chore: remove codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @sttomm @j0g3sc @pubudug


### PR DESCRIPTION
they trigger github to add mandatory reviews on every PR
if that's a process to keep, we need to reimplement it
given the new monorepo structure