### PR TITLE
feat(cli): make the browse command able to list/manipulate bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## vNext
+## v1.3.0 (vNext)
+
+This release comes with quite a bunch of new features
+
+### CLI
+
+- Added a `unipipe browse` command. This command allows interactively manipulating service instances and bindings in a repository. Great for semi-manual service workflows!
 
 ## v1.2.2
 

--- a/cli/unipipe/commands/browse.ts
+++ b/cli/unipipe/commands/browse.ts
@@ -6,7 +6,8 @@ import {
   prompt,
   Input,
 } from "../deps.ts";
-import { mapInstances } from "./helpers.ts";
+import { Repository } from "../repository.ts";
+import { stringify } from "../yaml.ts";
 import { show } from "./show.ts";
 import { STATUSES, update } from "./update.ts";
 
@@ -14,32 +15,35 @@ export function registerBrowseCmd(program: Command) {
   program
     .command("browse <repo>")
     .description("Interactively browse and manipulate a UniPipe OSB git repo.")
-    .action(async (opts: Record<never, never>, repo: string) => {
-      await browse(repo);
+    .action(async (_opts: Record<never, never>, repo: string) => {
+      const repository = new Repository(repo);
+      await browseInstances(repository);
     });
 }
 
-async function browse(osbRepoPath: string) {
-  const instanceOptions: SelectValueOptions = [];
-
+async function browseInstances(repo: Repository) {
   // We need to refresh the instance list select prompt before showing it.
   // Otherwise it's possible that e.g. a user updates an instance status but the instance list
   // does not reflect that when it's shown again. Replacing the select options array contents is not
   // exactly officially documented as supported by cliffy, but also not forbidden. It works though ;-)
+  const instanceOptions: SelectValueOptions = [];
   async function refreshInstanceList() {
     // deno-lint-ignore require-await
-    const opts = await mapInstances(osbRepoPath, async (x) => {
+    const opts = await repo.mapInstances(async (x) => {
       const i = x.instance;
       const plan = i.serviceDefinition.plans.filter(
         (x) => x.id === i.planId
       )[0];
 
       const name = [
-        colors.dim(i.serviceInstanceId),
-        colors.green(i.serviceDefinition.name),
-        colors.brightGreen(plan.name),
-        colors.blue(x.status?.status || "new"),
-        colors.red(i.deleted ? "deleted" : ""),
+        colors.dim("id: ") + colors.gray(i.serviceInstanceId),
+        colors.dim("service: ") + colors.green(i.serviceDefinition.name),
+        colors.dim("plan: ") + colors.yellow(plan.name),
+        colors.dim("bindings: ") +
+          colors.brightMagenta(x.bindings.length.toString()),
+        colors.dim("status: ") +
+          colors.blue(x.status?.status || "new") +
+          colors.red(i.deleted ? " deleted" : ""),
       ].join(" ");
 
       return { name, value: i.serviceInstanceId };
@@ -49,34 +53,97 @@ async function browse(osbRepoPath: string) {
     instanceOptions.push(...opts);
   }
 
+  const bindingOptions: SelectValueOptions = [];
+  async function refreshBindingList(instanceId: string) {
+    const instance = await repo.loadInstance(instanceId);
+    const opts = instance.bindings.map((x) => {
+      const name = [
+        colors.dim("id: ") + colors.gray(x.binding.bindingId),
+        // we could add binding paremeters in here,
+        colors.dim("params: ") +
+          colors.green(JSON.stringify(x.binding.parameters)),
+        colors.dim("status: ") +
+          colors.blue(x.status?.status || "new") +
+          colors.red(x.deleted ? " deleted" : ""),
+      ].join(" ");
+
+      return { name, value: x.binding.bindingId };
+    });
+
+    bindingOptions.length = 0;
+    bindingOptions.push(...opts);
+  }
+
   await refreshInstanceList();
 
   await prompt([
     {
-      name: "instances",
+      name: "selectInstance",
       type: Select,
       message: "Pick a service instance",
       options: instanceOptions,
     },
     {
-      name: "cmd",
+      name: "instanceCmd",
       message: "What do you want to do with this instance?",
       type: Select,
-      options: ["show", "update", "↑ instances"],
-      after: async ({ instances, cmd }, next) => {
+      options: ["show", "bindings", "update", "↑ instances"],
+      after: async ({ selectInstance, instanceCmd }, next) => {
+        const cmd = instanceCmd!!;
+        const instanceId = selectInstance!!;
         switch (cmd!!) {
           case "show":
-            await showInstance(osbRepoPath, instances!!);
-            next("cmd"); // loop
+            await showInstance(repo, instanceId);
+            next("instanceCmd"); // loop
             break;
-          case "update": {
-            await updateInstance(osbRepoPath, instances!!);
-            next("cmd"); // loop
+          case "bindings":
+            await refreshBindingList(instanceId);
+            next("selectBinding");
             break;
-          }
+          case "update":
+            await updateInstance(repo, instanceId);
+            next("instanceCmd"); // loop
+            break;
           case "↑ instances":
             await refreshInstanceList();
-            next("instances"); // back up
+            next("selectInstance"); // back up
+            break;
+          default:
+            break;
+        }
+      },
+    },
+    {
+      name: "selectBinding",
+      type: Select,
+      message: "Pick a service binding",
+      options: bindingOptions,
+    },
+    {
+      name: "bindingCmd",
+      message: "What do you want to do with this binding?",
+      type: Select,
+      options: ["show", "update", "↑ bindings", "↑ instances"],
+      after: async ({ selectInstance, selectBinding, bindingCmd }, next) => {
+        const instanceId = selectInstance!!;
+        const bindingId = selectBinding!!;
+        const cmd = bindingCmd!!;
+        switch (cmd) {
+          case "show":
+            await showBinding(repo, instanceId, bindingId);
+            next("bindingCmd"); // loop
+            break;
+          case "update":
+            await updateBinding(repo, instanceId, bindingId);
+            next("bindingCmd"); // loop
+            break;
+          case "↑ bindings":
+            await refreshBindingList(instanceId);
+            next("selectBinding"); // back up
+            break;
+          case "↑ instances":
+            await refreshInstanceList();
+            next("selectInstance"); // back up
             break;
           default:
             break;
@@ -86,15 +153,15 @@ async function browse(osbRepoPath: string) {
   ]);
 }
 
-async function showInstance(osbRepoPath: string, instanceId: string) {
-  await show(osbRepoPath, {
+async function showInstance(repository: Repository, instanceId: string) {
+  await show(repository, {
     instanceId: instanceId,
     outputFormat: "yaml",
     pretty: true,
   });
 }
 
-async function updateInstance(osbRepoPath: string, instanceId: any) {
+async function updateInstance(repo: Repository, instanceId: string) {
   const { status, description } = await prompt([
     {
       name: "status",
@@ -109,11 +176,61 @@ async function updateInstance(osbRepoPath: string, instanceId: any) {
     },
   ]);
 
-  await update(osbRepoPath, {
+  await update(repo, {
     instanceId,
     status: status,
     description: description,
   });
 
   console.log(`Updated status of instance ${instanceId} to '${status}'`);
+}
+
+async function updateBinding(
+  repo: Repository,
+  instanceId: string,
+  bindingId: string
+) {
+  const { status, description } = await prompt([
+    {
+      name: "status",
+      message: "What's the new status?",
+      type: Select,
+      options: STATUSES,
+    },
+    {
+      name: "description",
+      message: "Add a status descript status",
+      type: Input,
+    },
+  ]);
+
+  await update(repo, {
+    instanceId,
+    bindingId,
+    status: status,
+    description: description,
+  });
+
+  console.log(
+    `Updated status of instance ${instanceId} binding ${bindingId} to '${status}'`
+  );
+}
+
+async function showBinding(
+  repo: Repository,
+  instanceId: string,
+  bindingId: string
+) {
+  const instance = await repo.loadInstance(instanceId);
+  const binding = instance.bindings.find(
+    (x) => x.binding.bindingId === bindingId
+  );
+
+  if (!binding) {
+    throw new Error("Could not find binding with id: " + bindingId);
+  }
+  // todo: should probably centralize this code a bit
+  // todo: also consider printing the file paths for any "show" style command?
+  const p = { indent: 4 };
+  console.log(stringify(binding, p));
 }

--- a/cli/unipipe/commands/helpers.ts
+++ b/cli/unipipe/commands/helpers.ts
@@ -1,70 +1,6 @@
 import { path } from '../deps.ts';
-import { readBinding, readInstance, ServiceBinding, ServiceInstance } from '../osb.ts';
-
-/**
- * A helper function to implement commands that need to perform a map operation on instances.
- * 
- * NOTE: includes error handling, and will exit the process with an appropriate error message if an error occurs (e.g. directory not found, failed to process etc.)
- * @param osbRepoPath path to the osb repository
- * @param mapFn 
- * @returns 
- */
-export async function mapInstances<T>(
-  osbRepoPath: string,
-  mapFn: (serviceInstance: ServiceInstance) => Promise<T>,
-  filterFn: (serviceInstance: ServiceInstance) => boolean = (instance: ServiceInstance) => {
-    return true
-  }
-): Promise<T[]> {
-  const instancesPath = path.join(osbRepoPath, "instances");
-  const results: T[] = [];
-
-  try {
-    for await (const dir of Deno.readDir(instancesPath)) {
-      if (!dir.isDirectory) {
-        continue;
-      }
-
-      const ip = path.join(instancesPath, dir.name);
-
-      try {
-        const instance = await readInstance(ip);
-
-        const instancePassesFilter = filterFn(instance);
-        if (!instancePassesFilter) {
-          continue;
-        }
-
-        try {
-          const r = await mapFn(instance);
-          results.push(r);
-        } catch (error) {
-          console.error(
-            `Failed to process service instance "${ip}".\n`,
-            error
-          );
-          Deno.exit(1);
-        }
-
-      } catch (error) {
-        console.error(
-          `Failed to apply filter to service instance "${ip}".\n`,
-          error,
-        );
-        Deno.exit(1);
-      }
-    }
-  } catch (error) {
-    console.error(
-      `Failed to read instances directory "${instancesPath}".\n`,
-      error,
-    );
-    Deno.exit(1);
-  }
-
-  return results;
-}
-
+import { readBinding, ServiceBinding } from '../osb.ts';
+ 
 /**
  * A helper function to implement commands that need to perform a map operation on bindings.
  * If no bindings directory is found, an empty result is returned.
@@ -100,7 +36,7 @@ export async function mapBindings<T>(
         Deno.exit(1);
       }
     }
-  } catch (error) {
+  } catch (_error) {
     // Do not error when bindings directory does not exist.
   }
 

--- a/cli/unipipe/commands/show.ts
+++ b/cli/unipipe/commands/show.ts
@@ -1,6 +1,6 @@
-import { Command, EnumType, path } from '../deps.ts';
-import { readInstance } from '../osb.ts';
-import { stringify } from '../yaml.ts';
+import { Command, EnumType } from "../deps.ts";
+import { Repository } from "../repository.ts";
+import { stringify } from "../yaml.ts";
 
 const ALL_FORMATS = ["json", "yaml"] as const;
 type FormatsTuple = typeof ALL_FORMATS;
@@ -20,33 +20,23 @@ export function registerShowCmd(program: Command) {
     .command("show <repo>")
     .type("format", formatsType)
     .description(
-      "Shows the state stored service instance stored in a UniPipe OSB git repo.",
+      "Shows the state stored service instance stored in a UniPipe OSB git repo."
     )
-    .option(
-      "-i, --instance-id <id>",
-      "Service instance id.",
-    )
+    .option("-i, --instance-id <id>", "Service instance id.")
     .option(
       "-o, --output-format <output-format>",
       "Output format. Supported formats are yaml and json.",
       { default: "yaml" }
     )
-    .option(
-      "--pretty",
-      "Pretty print",
-    )
+    .option("--pretty", "Pretty print")
     .action(async (options: ShowOpts, repo: string) => {
-      await show(repo, options);
+      const repository = new Repository(repo);
+      await show(repository, options);
     });
 }
 
-export async function show(osbRepoPath: string, opts: ShowOpts) {
-  const instancesPath = path.join(
-    osbRepoPath,
-    "instances",
-    opts.instanceId,
-  );
-  const instance = await readInstance(instancesPath);
+export async function show(repository: Repository, opts: ShowOpts) {
+  const instance = await repository.loadInstance(opts.instanceId);
 
   switch (opts.outputFormat) {
     case "json": {
@@ -56,7 +46,7 @@ export async function show(osbRepoPath: string, opts: ShowOpts) {
     }
     case "yaml": {
       const p = opts.pretty ? { indent: 4 } : {};
-      console.log(stringify(instance as any, p));
+      console.log(stringify(instance, p));
       break;
     }
   }

--- a/cli/unipipe/info.ts
+++ b/cli/unipipe/info.ts
@@ -1,3 +1,3 @@
-export const VERSION = "1.2.4";
+export const VERSION = "1.2.4 (vnext)";
 export const FLAGS = "--unstable --allow-read --allow-write --allow-env --allow-net --allow-run";
 export const GITHUB_REPO = "meshcloud/unipipe-service-broker";

--- a/cli/unipipe/osb.ts
+++ b/cli/unipipe/osb.ts
@@ -1,15 +1,15 @@
-import { MeshMarketplaceContext } from './mesh.ts';
-import { parse } from './yaml.ts';
-import { mapBindings, mapInstances } from './commands/helpers.ts';
+import { MeshMarketplaceContext } from "./mesh.ts";
+import { parse } from "./yaml.ts";
+import { mapBindings } from "./commands/helpers.ts";
 
 export interface CloudFoundryContext {
-  // cloudfoundry context object, https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object  
+  // cloudfoundry context object, https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#cloud-foundry-context-object
   platform: "cloudfoundry";
   organization_name: string;
   space_name: string;
 }
 
-export interface OsbServiceInstance {
+export interface OsbServiceInstance extends Record<string, unknown> {
   serviceInstanceId: string;
   serviceDefinitionId: string;
   planId: string;
@@ -31,12 +31,12 @@ export interface OsbServiceInstance {
   metadata: {
     name: string;
   };
-  
+
   deleted?: boolean;
   // todo: more fields
 }
 
-export interface OsbServiceBinding {
+export interface OsbServiceBinding extends Record<string, unknown> {
   bindingId: string;
   serviceInstanceId: string;
   serviceDefinitionId: string;
@@ -51,29 +51,29 @@ export interface OsbServiceBinding {
   deleted: boolean;
 }
 
-export interface OsbServiceInstanceStatus {
-  status: "succeeded" | "failed";
+export interface OsbServiceInstanceStatus extends Record<string, unknown> {
+  status: "succeeded" | "in progress" | "failed";
   description: string;
 }
-export interface OsbServiceBindingStatus {
-  status: "succeeded" | "failed";
+export interface OsbServiceBindingStatus extends Record<string, unknown> {
+  status: "succeeded" | "in progress" | "failed";
   description: string;
 }
 
-export interface ServiceInstance {
+export interface ServiceInstance extends Record<string, unknown> {
   instance: OsbServiceInstance; // contents of instance.yml
   bindings: ServiceBinding[]; // contens of all bindings/$binding-id/binding.yml
   status: OsbServiceInstanceStatus | null; // contents of status.yml, null if not available
 }
 
-export interface ServiceBinding {
+export interface ServiceBinding extends Record<string, unknown> {
   binding: OsbServiceBinding; // content of bindings/$binding-id/binding.yml
   status: OsbServiceBindingStatus | null; // contents of status.yml, null if not available
 }
 /**
  * Parse a yaml file, throwing an error if it fails.
- * @param path 
- * @returns 
+ * @param path
+ * @returns
  */
 export async function parseYamlFile(path: string) {
   const yml = await Deno.readTextFile(path);
@@ -82,36 +82,33 @@ export async function parseYamlFile(path: string) {
 }
 /**
  * Attempts to parse a yaml file, returning null if the file does not exist or the YAML fails to parse.
- * @param path 
- * @returns 
+ * @param path
+ * @returns
  */
 export async function tryParseYamlFile(path: string) {
   try {
     const yml = await Deno.readTextFile(path);
     return parse(yml);
-  } catch (error) {
+  } catch (_error) {
     return null;
   }
 }
 
 /**
  * Reads an OSB service instance from the git repo structure
- * @param path 
- * @returns 
+ * @param path
+ * @returns
  */
 export async function readInstance(path: string): Promise<ServiceInstance> {
-  const instance = await parseYamlFile(
-    `${path}/instance.yml`,
-  ) as OsbServiceInstance;
+  const instance = (await parseYamlFile(
+    `${path}/instance.yml`
+  )) as OsbServiceInstance;
 
-  const status = await tryParseYamlFile(`${path}/status.yml`) as
-    | OsbServiceInstanceStatus
-    | null;
+  const status = (await tryParseYamlFile(
+    `${path}/status.yml`
+  )) as OsbServiceInstanceStatus | null;
 
-  const bindings = await mapBindings(
-    path,
-    async (binding) => await binding,
-  );
+  const bindings = await mapBindings(path, async (binding) => await binding);
 
   return {
     instance: instance,
@@ -122,20 +119,20 @@ export async function readInstance(path: string): Promise<ServiceInstance> {
 
 /**
  * Reads an OSB service binding from the git repo structure
- * @param path 
- * @returns 
+ * @param path
+ * @returns
  */
- export async function readBinding(path: string): Promise<ServiceBinding> {
-  const binding = await parseYamlFile(
-    `${path}/binding.yml`,
-  ) as OsbServiceBinding;
+export async function readBinding(path: string): Promise<ServiceBinding> {
+  const binding = (await parseYamlFile(
+    `${path}/binding.yml`
+  )) as OsbServiceBinding;
 
-  const status = await tryParseYamlFile(`${path}/status.yml`) as
-    | OsbServiceInstanceStatus
-    | null;
+  const status = (await tryParseYamlFile(
+    `${path}/status.yml`
+  )) as OsbServiceInstanceStatus | null;
 
-    return {
-      binding: binding,
-      status: status,
-    };
+  return {
+    binding: binding,
+    status: status,
+  };
 }

--- a/cli/unipipe/repository.ts
+++ b/cli/unipipe/repository.ts
@@ -1,0 +1,119 @@
+import { path } from "./deps.ts";
+import {
+  OsbServiceBindingStatus,
+  OsbServiceInstanceStatus,
+  readInstance,
+} from "./osb.ts";
+import { ServiceInstance } from "./osb.ts";
+import { stringify } from "./yaml.ts";
+
+export class Repository {
+  constructor(public readonly path: string) {}
+
+  /**
+   * Reads an OSB service instance from the git repo structure
+   * @returns
+   */
+  async loadInstance(instanceId: string): Promise<ServiceInstance> {
+    const instancePath = path.join(this.path, "instances", instanceId);
+    return await readInstance(instancePath);
+  }
+
+  /**
+   * A helper function to implement commands that need to perform a map operation on instances.
+   *
+   * NOTE: includes error handling, and will exit the process with an appropriate error message if an error occurs (e.g. directory not found, failed to process etc.)
+   * @param osbRepoPath path to the osb repository
+   * @param mapFn
+   * @returns
+   */
+  async mapInstances<T>(
+    mapFn: (serviceInstance: ServiceInstance) => Promise<T>,
+    filterFn: (serviceInstance: ServiceInstance) => boolean = (
+      _: ServiceInstance
+    ) => {
+      return true;
+    }
+  ): Promise<T[]> {
+    const instancesPath = path.join(this.path, "instances");
+    const results: T[] = [];
+
+    // todo: should probably not Deno.exit from here, but throw a nice exception and handle that globally
+    try {
+      for await (const dir of Deno.readDir(instancesPath)) {
+        if (!dir.isDirectory) {
+          continue;
+        }
+
+        const ip = path.join(instancesPath, dir.name);
+
+        try {
+          const instance = await readInstance(ip);
+
+          const instancePassesFilter = filterFn(instance);
+          if (!instancePassesFilter) {
+            continue;
+          }
+
+          try {
+            const r = await mapFn(instance);
+            results.push(r);
+          } catch (error) {
+            console.error(
+              `Failed to process service instance "${ip}".\n`,
+              error
+            );
+            Deno.exit(1);
+          }
+        } catch (error) {
+          console.error(
+            `Failed to apply filter to service instance "${ip}".\n`,
+            error
+          );
+          Deno.exit(1);
+        }
+      }
+    } catch (error) {
+      console.error(
+        `Failed to read instances directory "${instancesPath}".\n`,
+        error
+      );
+      Deno.exit(1);
+    }
+
+    return results;
+  }
+
+  async updateInstanceStatus(
+    instanceId: string,
+    status: OsbServiceInstanceStatus
+  ) {
+    const statusYmlPath = path.join(
+      this.path,
+      "instances",
+      instanceId,
+      "status.yml"
+    );
+
+    const yaml = stringify(status);
+    await Deno.writeTextFile(statusYmlPath, yaml);
+  }
+
+  async updateBindingStatus(
+    instanceId: string,
+    bindingId: string,
+    status: OsbServiceBindingStatus
+  ) {
+    const statusYmlPath = path.join(
+      this.path,
+      "instances",
+      instanceId,
+      "bindings",
+      bindingId,
+      "status.yml"
+    );
+
+    const yaml = stringify(status);
+    await Deno.writeTextFile(statusYmlPath, yaml);
+  }
+}


### PR DESCRIPTION
this comes with a refactoring that introduces a Repository abstraction
to handle unipipe osb repo structure (paths etc.) in a central
places.