### PR TITLE
feat: update credentials.yml files with unipipe-cli

### DIFF
--- a/cli/unipipe/commands/browse.ts
+++ b/cli/unipipe/commands/browse.ts
@@ -234,7 +234,7 @@ async function updateBinding(
     bindingId,
     status: status,
     description: description,
-    credential: credentials.length > 0 ? fixedCredentials : undefined,
+    credentials: credentials.length > 0 ? fixedCredentials : undefined,
   });
 
   console.log(

--- a/cli/unipipe/commands/browse.ts
+++ b/cli/unipipe/commands/browse.ts
@@ -5,6 +5,7 @@ import {
   SelectValueOptions,
   prompt,
   Input,
+  List,
 } from "../deps.ts";
 import { Repository } from "../repository.ts";
 import { stringify } from "../yaml.ts";
@@ -209,16 +210,35 @@ async function updateBinding(
       type: Input,
     },
   ]);
+  const credentials: string[] = await List.prompt(
+    {
+      message: "Add credential `key:value` pairs. Use comma `,` to separate credentials. If you don't want to update, leave it blank.",
+    }
+  );
+
+  // cliffy does not support whitespace in list prompt input.
+  // the following part is a workaround that adds the whitespace after the first colon character
+  var fixedCredentials: string[] = [];
+  credentials.forEach((credential) => {
+    const colonIndex = credential.indexOf(":");
+    if (colonIndex === -1) {
+      throw new Error("Could not find colon `:` in credential `key:value` pair: " + credential);
+    }
+    const key = credential.substring(0, colonIndex);
+    const value = credential.substring(colonIndex + 1);
+    fixedCredentials.push(key + ": " + value);
+  })
 
   await update(repo, {
     instanceId,
     bindingId,
     status: status,
     description: description,
+    credential: credentials.length > 0 ? fixedCredentials : undefined,
   });
 
   console.log(
-    `Updated status of instance ${instanceId} binding ${bindingId} to '${status}'`
+    `Updated status of instance ${instanceId} binding ${bindingId} to '${status}' and credentials are '${fixedCredentials.length > 0 ? 'overwritten' : 'not updated'}'`
   );
 }
 

--- a/cli/unipipe/commands/update.ts
+++ b/cli/unipipe/commands/update.ts
@@ -12,6 +12,7 @@ const statusesType = new EnumType(ALL_STATUSES);
 interface UpdateOpts {
   instanceId: string;
   bindingId?: string;
+  credential?: string[]
   status: Status;
   description: string;
 }
@@ -26,6 +27,10 @@ export function registerUpdateCmd(program: Command) {
     .option("-i --instance-id <instance-id>", "Service instance id.", {})
     .option("-b --binding-id <binding-id>", "Service binding id.", {
       depends: ["instance-id"],
+    })
+    .option("-c --credential <credential>", "Credential key-value.", {
+      collect: true,
+      depends: ["binding-id"],
     })
     .option(
       "--status <status:status>",
@@ -46,9 +51,17 @@ export async function update(repository: Repository, opts: UpdateOpts) {
     description: opts.description,
   };
 
+  var credentialsYaml = "";
+  opts.credential?.forEach(credential => {
+    credentialsYaml += `${credential}\n`;
+  })
+
   if (!opts.bindingId) {
     await repository.updateInstanceStatus(opts.instanceId, status);
   } else {
+    if (credentialsYaml != "") {
+      await repository.updateBindingCredentials(opts.instanceId, opts.bindingId, credentialsYaml);
+    }
     await repository.updateBindingStatus(
       opts.instanceId,
       opts.bindingId,

--- a/cli/unipipe/commands/update.ts
+++ b/cli/unipipe/commands/update.ts
@@ -12,7 +12,7 @@ const statusesType = new EnumType(ALL_STATUSES);
 interface UpdateOpts {
   instanceId: string;
   bindingId?: string;
-  credential?: string[]
+  credentials?: string[]
   status: Status;
   description: string;
 }
@@ -28,7 +28,7 @@ export function registerUpdateCmd(program: Command) {
     .option("-b --binding-id <binding-id>", "Service binding id.", {
       depends: ["instance-id"],
     })
-    .option("-c --credential <credential>", "Credential key-value.", {
+    .option("-c --credentials <credentials>", "Credential format `key: value`", {
       collect: true,
       depends: ["binding-id"],
     })
@@ -52,7 +52,7 @@ export async function update(repository: Repository, opts: UpdateOpts) {
   };
 
   var credentialsYaml = "";
-  opts.credential?.forEach(credential => {
+  opts.credentials?.forEach(credential => {
     credentialsYaml += `${credential}\n`;
   })
 

--- a/cli/unipipe/deps.ts
+++ b/cli/unipipe/deps.ts
@@ -27,3 +27,4 @@ export { UpgradeCommand, GithubProvider } from "https://deno.land/x/cliffy@v0.20
 export { Table } from "https://deno.land/x/cliffy@v0.20.1/table/mod.ts";
 export { prompt as prompt,Input,Select } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
 export type { SelectValueOptions } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
+export { List } from "https://deno.land/x/cliffy@v0.20.1/prompt/list.ts";

--- a/cli/unipipe/osb.ts
+++ b/cli/unipipe/osb.ts
@@ -69,6 +69,7 @@ export interface ServiceInstance extends Record<string, unknown> {
 export interface ServiceBinding extends Record<string, unknown> {
   binding: OsbServiceBinding; // content of bindings/$binding-id/binding.yml
   status: OsbServiceBindingStatus | null; // contents of status.yml, null if not available
+  credentials: Record<string, unknown> | null; // contents of credentials.yml
 }
 /**
  * Parse a yaml file, throwing an error if it fails.
@@ -131,8 +132,13 @@ export async function readBinding(path: string): Promise<ServiceBinding> {
     `${path}/status.yml`
   )) as OsbServiceInstanceStatus | null;
 
+  const credentials = (await tryParseYamlFile(
+    `${path}/credentials.yml`
+  )) as Record<string, unknown> | null;
+
   return {
     binding: binding,
     status: status,
+    credentials: credentials
   };
 }

--- a/cli/unipipe/repository.ts
+++ b/cli/unipipe/repository.ts
@@ -116,4 +116,21 @@ export class Repository {
     const yaml = stringify(status);
     await Deno.writeTextFile(statusYmlPath, yaml);
   }
+
+  async updateBindingCredentials(
+    instanceId: string,
+    bindingId: string,
+    credentials: string
+  ) {
+    const credentialsYmlPath = path.join(
+      this.path,
+      "instances",
+      instanceId,
+      "bindings",
+      bindingId,
+      "credentials.yml"
+    );
+
+    await Deno.writeTextFile(credentialsYmlPath, credentials);
+  }
 }

--- a/cli/unipipe/repository.ts
+++ b/cli/unipipe/repository.ts
@@ -130,7 +130,6 @@ export class Repository {
       bindingId,
       "credentials.yml"
     );
-
     await Deno.writeTextFile(credentialsYmlPath, credentials);
   }
 }

--- a/src/test/resources/expected_credentials.yml
+++ b/src/test/resources/expected_credentials.yml
@@ -1,0 +1,2 @@
+accesskey: MY_ACCESS_KEY
+secretkey: MY_SECRET_KEY


### PR DESCRIPTION
We can extend the feature a little bit more before the merge (maybe also adding browse cmd support as well). I opened this PR for the discussions and another contributions. It updates the credentials.yml file and changes the status file with a single command. we can also separate `credential` commands all together and add a new sub-command for it.

e.g adding multiple credentials: `unipipe update -i INSTANCE_ID -b BINDING_ID -c "username: doruk" -c "accesskey: test" -c "secretkey: ***" --status succeeded  REPO_PATH`