### PR TITLE
fix(cli): fix deno upgrade install

### DIFF
--- a/cli/unipipe/commands/upgrade.ts
+++ b/cli/unipipe/commands/upgrade.ts
@@ -1,35 +1,45 @@
-import { path, Command, GithubProvider, UpgradeCommand } from '../deps.ts';
-import { GITHUB_REPO, FLAGS, VERSION } from '../info.ts';
+import { Command, GithubProvider, GithubProviderOptions, path, UpgradeCommand } from '../deps.ts';
+import { FLAGS, GITHUB_REPO, VERSION } from '../info.ts';
 
 export function registerUpgradeCmd(program: Command) {
   const denoExecutable = Deno.execPath();
   const isRuntime = path.basename(denoExecutable) === "deno"; // simple and stupid, but avoids recursively invoking ourselves!
 
   if (!isRuntime) {
-    const msg = `Upgrade is only supported when unipipe cli was installed via "deno install".`;
+    const msg =
+      `Upgrade is only supported when unipipe cli was installed via "deno install".`;
     program
       .command("upgrade")
       .description(msg)
       .action(() => {
         console.error(
-          msg
-          + `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n`
-          + `\nTry installing via:\n`
-          + `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`
-
+          msg +
+            `\nThis version at ${denoExecutable} appears to be a self-contained binary.\n` +
+            `\nTry installing via:\n` +
+            `\n\tdeno install ${FLAGS} https://raw.githubusercontent.com/${GITHUB_REPO}/v${VERSION}/cli/unipipe/main.ts`,
         );
         Deno.exit(1);
       });
-  }
-  else {
+  } else {
     program.command(
       "upgrade",
       new UpgradeCommand({
         args: FLAGS.split(" "),
+        main: "main.ts",
         provider: [
-          new GithubProvider({ repository: GITHUB_REPO }),
+          new UnipipeGitHubProvider({ repository: GITHUB_REPO, branches: false }),
         ],
       }),
     );
+  }
+}
+
+class UnipipeGitHubProvider extends GithubProvider {
+  constructor(options: GithubProviderOptions) {
+    super({...options, });
+  }
+
+  override getRegistryUrl(_name: string, version: string): string {
+    return super.getRegistryUrl(_name, version) + "cli/unipipe/";
   }
 }

--- a/cli/unipipe/deps.ts
+++ b/cli/unipipe/deps.ts
@@ -6,7 +6,7 @@
 export * as path from "https://deno.land/std@0.115.1/path/mod.ts";
 export * as yaml from "https://deno.land/std@0.115.1/encoding/yaml.ts";
 export { v4 as uuid } from "https://deno.land/std@0.115.1/uuid/mod.ts";
-export * as colors from 'https://deno.land/std@0.115.1/fmt/colors.ts';
+export * as colors from "https://deno.land/std@0.115.1/fmt/colors.ts";
 
 // note: it's a bit ugly that we have to foray into the private parts of the stdlib, but otherwise we can't configure
 // the options we need
@@ -18,13 +18,21 @@ export { Schema as YamlSchema } from "https://deno.land/std@0.115.1/encoding/_ya
  */
 export {
   Command,
-  Type,
-  EnumType,
   CompletionsCommand,
+  EnumType,
+  Type,
 } from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
 export type { ITypeInfo } from "https://deno.land/x/cliffy@v0.20.1/command/mod.ts";
-export { UpgradeCommand, GithubProvider } from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
+export {
+  GithubProvider,
+  UpgradeCommand,
+} from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
+export type { GithubProviderOptions } from "https://deno.land/x/cliffy@v0.20.1/command/upgrade/mod.ts";
 export { Table } from "https://deno.land/x/cliffy@v0.20.1/table/mod.ts";
-export { prompt as prompt,Input,Select } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
+export {
+  Input,
+  prompt as prompt,
+  Select,
+} from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
 export type { SelectValueOptions } from "https://deno.land/x/cliffy@v0.20.1/prompt/mod.ts";
 export { List } from "https://deno.land/x/cliffy@v0.20.1/prompt/list.ts";

--- a/cli/unipipe/unipipe.sh
+++ b/cli/unipipe/unipipe.sh
@@ -3,5 +3,5 @@
 set -o errexit
 set -o nounset
 
-deno_flags=$(deno run flags.ts --quiet)
+deno_flags=$(deno run ../flags.ts --quiet)
 deno run $deno_flags "$(dirname "$0")"/main.ts "$@"

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,5 @@
 { pkgs ? import <nixpkgs> { } }:
 
-let
-  unstable = import <nixos-unstable> {};
-in
 pkgs.mkShell {
   NIX_SHELL = "unipipe";
   shellHook = ''
@@ -12,6 +9,6 @@ pkgs.mkShell {
   buildInputs = [    
 
     # node / typescript (meshPanel, utilities eetc.)
-    unstable.deno
+    pkgs.deno
   ];
 }


### PR DESCRIPTION
Now that unipipe-cli is part of the unipipe-service-broker mono repo, we need
the UpgradeCommand to use cli/unipipe/main.ts for locating the entry point
of the cli.