### PR TITLE
feat: Add basic terraform runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 tmp
 cf-manifest*.yml
 src/main/resources/ssh_key
+settings.json

--- a/cli/README.md
+++ b/cli/README.md
@@ -187,6 +187,9 @@ using typescript. This provides the following benefits:
 
 You need [deno](https://deno.land) installed on your system.
 
+If you are using VS Code, you also have to install the Deno extension and initialize the Deno workspace 
+via Cmd/Strg + Shift + P -> "Deno: Initialize Workspace Configuration"
+
 ```bash
 # running locally (using deno run, not compiled)
 ./unipipe/unipipe.sh --help

--- a/cli/unipipe/commands/terraform.ts
+++ b/cli/unipipe/commands/terraform.ts
@@ -1,0 +1,111 @@
+import { Command } from "../deps.ts";
+import { ServiceInstance } from "../handler.ts";
+import { ServiceBinding } from "../osb.ts";
+import { Repository } from "../repository.ts";
+
+// currently unused, but we most likely will introduce options soon
+interface TerraformOpts {
+}
+
+export function registerTerraformCmd(program: Command) {
+  program
+    .command("terraform [repo]")
+    .description(
+      "Runs Terraform modules located in the repository's terraform/<service_id> folder for all tenant service bindings. A" +
+      "TF_VAR_client_secret env variable must be set to provide the secret of the service principal that will be used for applying " +
+      "Terraform.",
+    )
+    .action(async (options: TerraformOpts, repo: string | undefined) => {
+      const repository = new Repository(repo ? repo : ".");
+      const out = await run(repository, options);
+      console.log(out);
+    });
+}
+
+export async function run(
+  repo: Repository,
+  opts: TerraformOpts,
+): Promise<string[][]> {
+  const instances = await repo.mapInstances(async (instance) => {
+    return await instance;
+  });
+
+  return await Promise.all(
+    instances.map((instance) => mapBindings(instance, repo)),
+  );
+}
+
+async function mapBindings(
+  instance: ServiceInstance,
+  repo: Repository,
+): Promise<string[]> {
+  return await Promise.all(
+    instance.bindings.map((binding) => processBinding(instance, binding, repo)),
+  );
+}
+
+async function processBinding(
+  instance: ServiceInstance,
+  binding: ServiceBinding,
+  repo: Repository,
+): Promise<string> {
+  const wrapper = {
+    variable: {
+      client_secret: {
+        description: "Client Secret of the Azure App Registration.",
+        type: "string",
+        sensitive: true,
+      },
+    },
+    module: {
+      wrapper: {
+        source:
+          `../../../../terraform/${instance.instance.serviceDefinitionId}`,
+        client_secret: "${var.client_secret}",
+        ...instance.instance.parameters,
+        ...binding.binding.bindResource,
+        ...binding.binding.parameters
+        // TODO We should also consider adding tags as parameters. Because currently for me meshStack or a policy that
+        // is defined via a LZ always sets tags, that get removed again on terraform apply, as we don't define them here.
+      },
+    },
+  };
+
+  const bindingDir =
+    `${repo.path}/instances/${instance.instance.serviceInstanceId}/bindings/${binding.binding.bindingId}`;
+
+  Deno.writeTextFile(
+    `${bindingDir}/module.tf.json`,
+    JSON.stringify(wrapper, null, 2),
+  );
+
+  const tfResult = await executeTerraform(bindingDir);
+
+  const bindingIdentifier = instance.instance.serviceInstanceId + "/" + binding.binding.bindingId + ": ";
+
+  return  +
+    tfResult.success ? bindingIdentifier + "successful" : bindingIdentifier + "failed";
+}
+
+// TODO write log to a service binding specific log file (can be overwritten on every new run)
+async function executeTerraform(
+  bindingDir: string,
+): Promise<Deno.ProcessStatus> {
+  console.log("Running Terraform Init for " + bindingDir);
+
+  const tfInit = Deno.run({
+    cmd: ["terraform", "init"],
+    cwd: bindingDir,
+  });
+
+  await tfInit.status();
+
+  console.log("Running Terraform Apply for " + bindingDir);
+
+  const tfApply = Deno.run({
+    cmd: ["terraform", "apply", "-auto-approve"],
+    cwd: bindingDir,
+  });
+
+  return await tfApply.status();
+}

--- a/cli/unipipe/main.ts
+++ b/cli/unipipe/main.ts
@@ -1,10 +1,11 @@
+import { registerBrowseCmd } from "./commands/browse.ts";
 import { registerGenerateCmd } from "./commands/generate.ts";
 import { registerListCmd } from "./commands/list.ts";
 import { registerShowCmd } from "./commands/show.ts";
+import { registerTerraformCmd } from "./commands/terraform.ts";
 import { registerTransformCmd } from "./commands/transform.ts";
 import { registerUpdateCmd } from "./commands/update.ts";
 import { registerUpgradeCmd } from "./commands/upgrade.ts";
-import { registerBrowseCmd } from "./commands/browse.ts";
 import { Command, CompletionsCommand } from "./deps.ts";
 import { VERSION } from "./info.ts";
 
@@ -22,6 +23,7 @@ registerUpdateCmd(program);
 registerGenerateCmd(program);
 registerUpgradeCmd(program);
 registerBrowseCmd(program);
+registerTerraformCmd(program);
 
 const hasArgs = Deno.args.length > 0;
 if (hasArgs) {


### PR DESCRIPTION
For several service brokers, execution of a Terraform Module is the central task they have to execute. With the new unipipe terraform command, we now provide support for this task. The Terraform module must exist in the git repository that also contains the instances ina terraform/<serviceId> folder. It must be compatible with a specific set of variables that will be provided to it via the unipipe terraform command.