### PR TITLE
fix: Replaced single tick with apostrophe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## vNext
+### CLI
+
+- Fixed zsh completions
 
 ## v1.6.0
 ### CLI

--- a/cli/unipipe/commands/terraform.ts
+++ b/cli/unipipe/commands/terraform.ts
@@ -11,7 +11,7 @@ export function registerTerraformCmd(program: Command) {
   program
     .command("terraform [repo]")
     .description(
-      "Runs Terraform modules located in the repository's terraform/<service_id> folder for all tenant service bindings. A" +
+      "Runs Terraform modules located in the repository’s terraform/<service_id> folder for all tenant service bindings. A " +
         "TF_VAR_platform_secret env variable must be set to provide the secret of the service principal that will be used for applying " +
         "Terraform.",
     )


### PR DESCRIPTION
The zsh completions cliffy generates could not be sourced when we introduced a single quote in the command desription of `unipipe terraform`.
This fixes the zsh completions.

This is what the relevant part of the `unipipe completions zsh` generated file looked like before this fix:

<img width="1092" alt="image" src="https://user-images.githubusercontent.com/67903933/196770096-b7d0679b-7189-4a29-970b-6daa286f27ed.png">