### PR TITLE
feat: unipipe terraform can handle instances without binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### CLI
 
 - Fixed zsh completions
+- `unipipe terraform` updates status.yml to succeeded for service instances without any binding
 
 ## v1.6.0
 ### CLI


### PR DESCRIPTION
unipipe terraform requires a binding to actually execute terraform code. But the flow in a marketplace is that first an instance is created and once it is successfully provisioned, the binding can be created. With this new behavior, an instance without bindings will simply be set to succeeded, so bindings can be created for it.