### PR TITLE
fix redirection; now works with azure container instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## vNext
 
+- terraform-runner logs in Azure Container Instances
+
 ## v1.7.0
 ### CLI
 

--- a/terraform-runner/unipipe-terraform-cron
+++ b/terraform-runner/unipipe-terraform-cron
@@ -1,1 +1,1 @@
-* * * * * ~/unipipe/run-unipipe-terraform.sh > /proc/1/fd/1 2>/proc/1/fd/2
+* * * * * ~/unipipe/run-unipipe-terraform.sh >&1 2>&2

--- a/terraform-runner/unipipe-terraform-cron
+++ b/terraform-runner/unipipe-terraform-cron
@@ -1,1 +1,1 @@
-* * * * * ~/unipipe/run-unipipe-terraform.sh >&1 2>&2
+* * * * * ~/unipipe/run-unipipe-terraform.sh


### PR DESCRIPTION
The cronjob failed for containers on ACI when redirecting to /proc/1/fd/N

Colors on Azure Container Instance logs are broken but running `az container logs` on the container shows colors, so that is a problem with the Azure log window on the portal.
![image](https://user-images.githubusercontent.com/67903933/199739463-7cc4e21f-97af-40ae-bddd-c9494d52de7b.png) 
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/67903933/199739918-1b9692ab-6fc2-4e85-a8ff-793f65c6d143.png">

I also tested the new redirection with our development container in Kubernetes.