### PR TITLE
fix: abort cron job if git repo prep fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### CLI
 - new command unipipe generate terraform-runner-hello-world will generate a sample catalog + terraform files for use with unipipe terraform command
 
+### Terraform Runner
+- Improve runner script robustness
+- Abort cron job if Git repo setup fails
+
 ## v1.7.1
 
 ### Terraform Runner

--- a/terraform-runner/run-unipipe-terraform.sh
+++ b/terraform-runner/run-unipipe-terraform.sh
@@ -1,15 +1,20 @@
-#! /bin/bash
+#!/usr/bin/env bash
+# Exit on all errors and undefined vars
+set -o errexit
+set -o errtrace
+set -o pipefail
+set -o nounset
 
 REPO_NAME=instances-repo
 REPO_DIR=~/unipipe/$REPO_NAME
-if [ ! -f "$REPO_DIR" ]; then
-    cat >~/.ssh/id_rsa <<< "${GIT_SSH_KEY}"
+if [[ ! -d "$REPO_DIR" ]]; then
+    cat > ~/.ssh/id_rsa <<< "${GIT_SSH_KEY}"
     chmod 700 ~/.ssh
     chmod 600 ~/.ssh/id_rsa
     cd ~/unipipe
-    git config --global user.email $GIT_USER_EMAIL
-    git config --global user.name $GIT_USER_NAME
-    git clone $GIT_REMOTE $REPO_NAME
+    git config --global user.email "$GIT_USER_EMAIL"
+    git config --global user.name "$GIT_USER_NAME"
+    git clone "$GIT_REMOTE" "$REPO_NAME"
 fi
 
 cd $REPO_DIR


### PR DESCRIPTION
The script should abort when we run into issues with the Git setup.