### PR TITLE
Add new git command to Unipipe CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,6 @@
 ## vNext
 
 ### CLI
-- no changes
-
-### OSB
-- no changes
-
-### Terraform Runner
-- no changes
-
-## v1.7.3
-
-### CLI
 - New command `unipipe git` runs Git pull/push commands resiliently. It takes care of retrying and rebasing if needed to make sure a push will be successful.
 
 ### OSB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 ### Terraform Runner
 - no changes
 
+## v1.7.3
+
+### CLI
+- New command `unipipe git` runs Git pull/push commands resiliently. It takes care of retrying and rebasing if needed to make sure a push will be successful.
+
+### OSB
+- no changes
+
+### Terraform Runner
+- no changes
+
 ## v1.7.2
 
 ### CLI

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -1,0 +1,52 @@
+import { assertSpyCall, assertSpyCalls, Stub, stub, returnsNext } from "../dev_deps.ts";
+import { withTempDir } from "../test-util.ts";
+import { Repository } from "../repository.ts";
+import { commandPull } from "./git.ts";
+
+Deno.test(
+  "can pull with fast forward",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        createMockedResult()
+      ]);
+
+      await commandPull(new Repository(tmp));
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 1);      
+      strub.restore();      
+    })
+);
+
+function createMockedGit(mockedResults: unknown[]): Stub {
+  return stub(
+    Deno,
+    "run",        
+    returnsNext(mockedResults)
+  );
+}
+
+function createMockedResult(success = true) {
+  return {
+    status: () => {
+      return {
+        success: success,
+        code: 0,
+        signal: undefined
+      }
+    }
+  };
+}
+

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -168,36 +168,6 @@ Deno.test(
 );
 
 Deno.test(
-  "can commit with custom author and commit message",
-  async () =>
-    await withTempDir(async (dir) => {
-
-      const stub = createMockedGit([
-        successfulResult(),
-        failedResult(),
-        successfulResult(),        
-        successfulResult()
-      ]);
-
-      const opts: GitOpts = {
-        name: "John Doe",
-        email: "john@doe.loc",
-        message: "Some changes"
-
-      }
-      await commandPush(new Repository(dir), opts);
-
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Some changes", "--author", "John Doe <john@doe.loc>"]);
-      assertGit(dir, stub, 3, [ "git", "push" ]);
-      assertSpyCalls(stub, 4);
-
-      stub.restore();
-    })
-);
-
-Deno.test(
   "can commit and push changes with upstream conflicts (fast-forward)",
   async () =>
     await withTempDir(async (dir) => {
@@ -250,6 +220,36 @@ Deno.test(
       assertGit(dir, stub, 5, [ "git", "pull", "--rebase" ]);
       assertGit(dir, stub, 6, [ "git", "push" ]);
       assertSpyCalls(stub, 7);
+
+      stub.restore();
+    })
+);
+
+Deno.test(
+  "can commit with custom author and commit message",
+  async () =>
+    await withTempDir(async (dir) => {
+
+      const stub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(),        
+        successfulResult()
+      ]);
+
+      const opts: GitOpts = {
+        name: "John Doe",
+        email: "john@doe.loc",
+        message: "Some changes"
+      }
+      
+      await commandPush(new Repository(dir), opts);
+
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Some changes", "--author", "John Doe <john@doe.loc>"]);
+      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyCalls(stub, 4);
 
       stub.restore();
     })

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -52,7 +52,7 @@ Deno.test(
 );
 
 Deno.test(
-  "can pull with rebase with no local chnages",
+  "can pull with rebase with no local changes",
   async () =>
     await withTempDir(async (dir) => {
 
@@ -77,7 +77,7 @@ Deno.test(
 );
 
 Deno.test(
-  "can pull with rebase with local chnages",
+  "can pull with rebase with local changes",
   async () =>
     await withTempDir(async (dir) => {
 
@@ -159,7 +159,7 @@ Deno.test(
 
       assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
       assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Unipipe CLI <unipipe-cli@meshcloud.io>"]);
       assertSpyGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyCalls(stub, 4);
 
@@ -185,7 +185,7 @@ Deno.test(
 
       assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
       assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Unipipe CLI <unipipe-cli@meshcloud.io>"]);
       assertSpyGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
       assertSpyGit(dir, stub, 5, [ "git", "push" ]);
@@ -214,7 +214,7 @@ Deno.test(
 
       assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
       assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>", ]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Unipipe CLI <unipipe-cli@meshcloud.io>", ]);
       assertSpyGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
       assertSpyGit(dir, stub, 5, [ "git", "pull", "--rebase" ]);

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -1,7 +1,7 @@
 import { assertSpyCall, assertSpyCalls, Stub, stub, returnsNext } from "../dev_deps.ts";
 import { withTempDir } from "../test-util.ts";
 import { Repository } from "../repository.ts";
-import { commandPull } from "./git.ts";
+import { commandPull, commandPush } from "./git.ts";
 
 Deno.test(
   "can pull with fast forward",
@@ -9,7 +9,7 @@ Deno.test(
     await withTempDir(async (tmp) => {
 
       const strub = createMockedGit([
-        createMockedResult()
+        successfulResult()
       ]);
 
       await commandPull(new Repository(tmp));
@@ -30,6 +30,382 @@ Deno.test(
     })
 );
 
+Deno.test(
+  "can pull with rebase",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        failedResult(),
+        successfulResult()        
+      ]);
+
+      await commandPull(new Repository(tmp));
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--rebase"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 2);      
+      strub.restore();      
+    })
+);
+
+Deno.test(
+  "do not push if the repository is not initialized",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        failedResult()
+      ]);
+
+      await commandPush(new Repository(tmp), {});
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "add",
+            "."
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 1);
+      strub.restore();
+    })
+);
+
+Deno.test(
+  "do not commit if there are no changes while pushing",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        successfulResult(),
+        successfulResult()
+      ]);
+
+      await commandPush(new Repository(tmp), {});
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "add",
+            "."
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 3);
+      strub.restore();
+    })
+);
+
+Deno.test(
+  "can commit and push changes without upstream conflicts",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(),        
+        successfulResult()
+      ]);
+
+      await commandPush(new Repository(tmp), {});
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "add",
+            "."
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "commit",
+            "-a",
+            "-m",
+            "Unipipe CLI: Commit changes",
+            "--author",
+            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 4);
+      strub.restore();
+    })
+);
+
+Deno.test(
+  "can commit and push changes with upstream conflicts (fast-forward)",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(), 
+        failedResult(),
+        successfulResult(),
+        successfulResult()
+      ]);
+
+      await commandPush(new Repository(tmp), {});
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "add",
+            "."
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "commit",
+            "-a",
+            "-m",
+            "Unipipe CLI: Commit changes",
+            "--author",
+            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 4, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 5, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 6);
+      strub.restore();
+    })
+);
+
+Deno.test(
+  "can commit and push changes with upstream conflicts (rebase)",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(), 
+        failedResult(),
+        failedResult(),
+        successfulResult(),
+        successfulResult()
+      ]);
+
+      await commandPush(new Repository(tmp), {});
+
+      assertSpyCall(strub, 0, {
+        args: [{
+          cmd: [
+            "git",
+            "add",
+            "."
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "commit",
+            "-a",
+            "-m",
+            "Unipipe CLI: Commit changes",
+            "--author",
+            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 4, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 5, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--rebase"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 6, {
+        args: [{
+          cmd: [
+            "git",
+            "push"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 7);
+      strub.restore();
+    })
+);
+
 function createMockedGit(mockedResults: unknown[]): Stub {
   return stub(
     Deno,
@@ -38,7 +414,15 @@ function createMockedGit(mockedResults: unknown[]): Stub {
   );
 }
 
-function createMockedResult(success = true) {
+function successfulResult() {
+  return createMockedResult(true)
+}
+
+function failedResult() {
+  return createMockedResult(false)
+}
+
+function createMockedResult(success: boolean) {
   return {
     status: () => {
       return {
@@ -49,4 +433,3 @@ function createMockedResult(success = true) {
     }
   };
 }
-

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -16,9 +16,9 @@ Deno.test(
 
       await commandPull(new Repository(dir));
 
-      assertGit(dir, stub, 0, ["git", "add", "."]);
-      assertGit(dir, stub, 1, ["git", "diff-index", "--quiet", "HEAD", "--"])
-      assertGit(dir, stub, 2, ["git", "pull", "--ff-only"])      
+      assertSpyGit(dir, stub, 0, ["git", "add", "."]);
+      assertSpyGit(dir, stub, 1, ["git", "diff-index", "--quiet", "HEAD", "--"])
+      assertSpyGit(dir, stub, 2, ["git", "pull", "--ff-only"])      
       assertSpyCalls(stub, 3);      
 
       stub.restore();      
@@ -40,11 +40,11 @@ Deno.test(
 
       await commandPull(new Repository(dir));
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "stash" ]);
-      assertGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
-      assertGit(dir, stub, 4, [ "git", "stash", "pop" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "stash" ]);
+      assertSpyGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
+      assertSpyGit(dir, stub, 4, [ "git", "stash", "pop" ]);
       assertSpyCalls(stub, 5);
 
       stub.restore();      
@@ -66,10 +66,10 @@ Deno.test(
 
       await commandPull(new Repository(dir));
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);      
-      assertGit(dir, stub, 2, [ "git", "pull", "--ff-only" ]);
-      assertGit(dir, stub, 3, [ "git", "pull", "--rebase" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);      
+      assertSpyGit(dir, stub, 2, [ "git", "pull", "--ff-only" ]);
+      assertSpyGit(dir, stub, 3, [ "git", "pull", "--rebase" ]);
       assertSpyCalls(stub, 4);      
 
       stub.restore();      
@@ -93,12 +93,12 @@ Deno.test(
 
       await commandPull(new Repository(dir));
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "stash" ]);
-      assertGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
-      assertGit(dir, stub, 4, [ "git", "pull", "--rebase" ]);
-      assertGit(dir, stub, 5, [ "git", "stash", "pop" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "stash" ]);
+      assertSpyGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
+      assertSpyGit(dir, stub, 4, [ "git", "pull", "--rebase" ]);
+      assertSpyGit(dir, stub, 5, [ "git", "stash", "pop" ]);
       assertSpyCalls(stub, 6);      
 
       stub.restore();      
@@ -116,7 +116,7 @@ Deno.test(
 
       await commandPush(new Repository(dir), {});
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
       assertSpyCalls(stub, 1);
 
       stub.restore();
@@ -135,8 +135,8 @@ Deno.test(
 
       await commandPush(new Repository(dir), {});
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
       assertSpyCalls(stub, 2);
 
       stub.restore();
@@ -157,10 +157,10 @@ Deno.test(
 
       await commandPush(new Repository(dir), {});
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
-      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertSpyGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyCalls(stub, 4);
 
       stub.restore();
@@ -183,12 +183,12 @@ Deno.test(
 
       await commandPush(new Repository(dir), {});
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
-      assertGit(dir, stub, 3, [ "git", "push" ]);
-      assertGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
-      assertGit(dir, stub, 5, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertSpyGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
+      assertSpyGit(dir, stub, 5, [ "git", "push" ]);
       assertSpyCalls(stub, 6);
 
       stub.restore();
@@ -212,13 +212,13 @@ Deno.test(
 
       await commandPush(new Repository(dir), {});
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>", ]);
-      assertGit(dir, stub, 3, [ "git", "push" ]);
-      assertGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
-      assertGit(dir, stub, 5, [ "git", "pull", "--rebase" ]);
-      assertGit(dir, stub, 6, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>", ]);
+      assertSpyGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
+      assertSpyGit(dir, stub, 5, [ "git", "pull", "--rebase" ]);
+      assertSpyGit(dir, stub, 6, [ "git", "push" ]);
       assertSpyCalls(stub, 7);
 
       stub.restore();
@@ -245,10 +245,10 @@ Deno.test(
       
       await commandPush(new Repository(dir), opts);
 
-      assertGit(dir, stub, 0, [ "git", "add", "." ]);
-      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
-      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Some changes", "--author", "John Doe <john@doe.loc>"]);
-      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Some changes", "--author", "John Doe <john@doe.loc>"]);
+      assertSpyGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyCalls(stub, 4);
 
       stub.restore();
@@ -283,7 +283,7 @@ function createMockedResult(success: boolean) {
   };
 }
 
-function assertGit(dir: string, stub: Stub, callIndex: number, args: string[]) {
+function assertSpyGit(dir: string, stub: Stub, callIndex: number, args: string[]) {
   assertSpyCall(stub, callIndex, {
     args: [{
       cmd: args,

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -103,7 +103,6 @@ Deno.test(
 
       const strub = createMockedGit([
         successfulResult(),
-        successfulResult(),
         successfulResult()
       ]);
 
@@ -132,17 +131,7 @@ Deno.test(
         }]
       });
 
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 3);
+      assertSpyCalls(strub, 2);
       strub.restore();
     })
 );

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -6,62 +6,31 @@ import { commandPull, commandPush } from "./git.ts";
 Deno.test(
   "can pull with fast forward with no local changes",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         successfulResult(),
         successfulResult()
       ]);
 
-      await commandPull(new Repository(tmp));
+      await commandPull(new Repository(dir));
 
-      assertSpyCall(strub, 0, { 
-        args: [{ 
-          cmd: [ 
-            "git",
-            "add",
-            "."
-          ], 
-          cwd: tmp 
-        }]
-      });
+      assertGit(dir, stub, 0, ["git", "add", "."]);
+      assertGit(dir, stub, 1, ["git", "diff-index", "--quiet", "HEAD", "--"])
+      assertGit(dir, stub, 2, ["git", "pull", "--ff-only"])      
+      assertSpyCalls(stub, 3);      
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 3);      
-      strub.restore();      
+      stub.restore();      
     })
 );
 
 Deno.test(
   "can pull with fast forward with local changes",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         failedResult(),
         successfulResult(),
@@ -69,75 +38,25 @@ Deno.test(
         successfulResult()
       ]);
 
-      await commandPull(new Repository(tmp));
+      await commandPull(new Repository(dir));
 
-      assertSpyCall(strub, 0, { 
-        args: [{ 
-          cmd: [ 
-            "git",
-            "add",
-            "."
-          ], 
-          cwd: tmp 
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "stash" ]);
+      assertGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
+      assertGit(dir, stub, 4, [ "git", "stash", "pop" ]);
+      assertSpyCalls(stub, 5);
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "stash"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 4, {
-        args: [{
-          cmd: [
-            "git",
-            "stash",
-            "pop"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 5);      
-      strub.restore();      
+      stub.restore();      
     })
 );
 
 Deno.test(
   "can pull with rebase with no local chnages",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         successfulResult(),
         failedResult(),
@@ -145,65 +64,24 @@ Deno.test(
         successfulResult(),
       ]);
 
-      await commandPull(new Repository(tmp));
+      await commandPull(new Repository(dir));
 
-      assertSpyCall(strub, 0, { 
-        args: [{ 
-          cmd: [ 
-            "git",
-            "add",
-            "."
-          ], 
-          cwd: tmp 
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);      
+      assertGit(dir, stub, 2, [ "git", "pull", "--ff-only" ]);
+      assertGit(dir, stub, 3, [ "git", "pull", "--rebase" ]);
+      assertSpyCalls(stub, 4);      
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--rebase"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 4);      
-      strub.restore();      
+      stub.restore();      
     })
 );
 
 Deno.test(
   "can pull with rebase with local chnages",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         failedResult(),
         successfulResult(),
@@ -213,222 +91,88 @@ Deno.test(
         successfulResult()
       ]);
 
-      await commandPull(new Repository(tmp));
+      await commandPull(new Repository(dir));
 
-      assertSpyCall(strub, 0, { 
-        args: [{ 
-          cmd: [ 
-            "git",
-            "add",
-            "."
-          ], 
-          cwd: tmp 
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "stash" ]);
+      assertGit(dir, stub, 3, [ "git", "pull", "--ff-only" ]);
+      assertGit(dir, stub, 4, [ "git", "pull", "--rebase" ]);
+      assertGit(dir, stub, 5, [ "git", "stash", "pop" ]);
+      assertSpyCalls(stub, 6);      
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "stash"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 4, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--rebase"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 5, {
-        args: [{
-          cmd: [
-            "git",
-            "stash",
-            "pop"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 6);      
-      strub.restore();      
+      stub.restore();      
     })
 );
 
 Deno.test(
   "do not push if the repository is not initialized",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         failedResult()
       ]);
 
-      await commandPush(new Repository(tmp), {});
+      await commandPush(new Repository(dir), {});
 
-      assertSpyCall(strub, 0, {
-        args: [{
-          cmd: [
-            "git",
-            "add",
-            "."
-          ],
-          cwd: tmp
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertSpyCalls(stub, 1);
 
-      assertSpyCalls(strub, 1);
-      strub.restore();
+      stub.restore();
     })
 );
 
 Deno.test(
   "do not commit if there are no changes while pushing",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         successfulResult()
       ]);
 
-      await commandPush(new Repository(tmp), {});
+      await commandPush(new Repository(dir), {});
 
-      assertSpyCall(strub, 0, {
-        args: [{
-          cmd: [
-            "git",
-            "add",
-            "."
-          ],
-          cwd: tmp
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertSpyCalls(stub, 2);
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 2);
-      strub.restore();
+      stub.restore();
     })
 );
 
 Deno.test(
   "can commit and push changes without upstream conflicts",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         failedResult(),
         successfulResult(),        
         successfulResult()
       ]);
 
-      await commandPush(new Repository(tmp), {});
+      await commandPush(new Repository(dir), {});
 
-      assertSpyCall(strub, 0, {
-        args: [{
-          cmd: [
-            "git",
-            "add",
-            "."
-          ],
-          cwd: tmp
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyCalls(stub, 4);
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "commit",
-            "-a",
-            "-m",
-            "Unipipe CLI: Commit changes",
-            "--author",
-            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 4);
-      strub.restore();
+      stub.restore();
     })
 );
 
 Deno.test(
   "can commit and push changes with upstream conflicts (fast-forward)",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         failedResult(),
         successfulResult(), 
@@ -437,89 +181,26 @@ Deno.test(
         successfulResult()
       ]);
 
-      await commandPush(new Repository(tmp), {});
+      await commandPush(new Repository(dir), {});
 
-      assertSpyCall(strub, 0, {
-        args: [{
-          cmd: [
-            "git",
-            "add",
-            "."
-          ],
-          cwd: tmp
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
+      assertGit(dir, stub, 5, [ "git", "push" ]);
+      assertSpyCalls(stub, 6);
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "commit",
-            "-a",
-            "-m",
-            "Unipipe CLI: Commit changes",
-            "--author",
-            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 4, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 5, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 6);
-      strub.restore();
+      stub.restore();
     })
 );
 
 Deno.test(
   "can commit and push changes with upstream conflicts (rebase)",
   async () =>
-    await withTempDir(async (tmp) => {
+    await withTempDir(async (dir) => {
 
-      const strub = createMockedGit([
+      const stub = createMockedGit([
         successfulResult(),
         failedResult(),
         successfulResult(), 
@@ -529,91 +210,18 @@ Deno.test(
         successfulResult()
       ]);
 
-      await commandPush(new Repository(tmp), {});
+      await commandPush(new Repository(dir), {});
 
-      assertSpyCall(strub, 0, {
-        args: [{
-          cmd: [
-            "git",
-            "add",
-            "."
-          ],
-          cwd: tmp
-        }]
-      });
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>", ]);
+      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertGit(dir, stub, 4, [ "git", "pull", "--ff-only" ]);
+      assertGit(dir, stub, 5, [ "git", "pull", "--rebase" ]);
+      assertGit(dir, stub, 6, [ "git", "push" ]);
+      assertSpyCalls(stub, 7);
 
-      assertSpyCall(strub, 1, {
-        args: [{
-          cmd: [
-            "git",
-            "diff-index",
-            "--quiet",
-            "HEAD",
-            "--"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 2, {
-        args: [{
-          cmd: [
-            "git",
-            "commit",
-            "-a",
-            "-m",
-            "Unipipe CLI: Commit changes",
-            "--author",
-            "Uncoipipe CLI <unipipe-cli@meshcloud.io>",
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 3, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 4, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--ff-only"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 5, {
-        args: [{
-          cmd: [
-            "git",
-            "pull",
-            "--rebase"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCall(strub, 6, {
-        args: [{
-          cmd: [
-            "git",
-            "push"
-          ],
-          cwd: tmp
-        }]
-      });
-
-      assertSpyCalls(strub, 7);
-      strub.restore();
+      stub.restore();
     })
 );
 
@@ -643,4 +251,13 @@ function createMockedResult(success: boolean) {
       }
     }
   };
+}
+
+function assertGit(dir: string, stub: Stub, callIndex: number, args: string[]) {
+  assertSpyCall(stub, callIndex, {
+    args: [{
+      cmd: args,
+      cwd: dir
+    }]
+  });
 }

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -1,7 +1,7 @@
 import { assertSpyCall, assertSpyCalls, Stub, stub, returnsNext } from "../dev_deps.ts";
 import { withTempDir } from "../test-util.ts";
 import { Repository } from "../repository.ts";
-import { commandPull, commandPush } from "./git.ts";
+import { commandPull, commandPush, GitOpts } from "./git.ts";
 
 Deno.test(
   "can pull with fast forward with no local changes",
@@ -160,6 +160,36 @@ Deno.test(
       assertGit(dir, stub, 0, [ "git", "add", "." ]);
       assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
       assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Commit changes", "--author", "Uncoipipe CLI <unipipe-cli@meshcloud.io>"]);
+      assertGit(dir, stub, 3, [ "git", "push" ]);
+      assertSpyCalls(stub, 4);
+
+      stub.restore();
+    })
+);
+
+Deno.test(
+  "can commit with custom author and commit message",
+  async () =>
+    await withTempDir(async (dir) => {
+
+      const stub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(),        
+        successfulResult()
+      ]);
+
+      const opts: GitOpts = {
+        name: "John Doe",
+        email: "john@doe.loc",
+        message: "Some changes"
+
+      }
+      await commandPush(new Repository(dir), opts);
+
+      assertGit(dir, stub, 0, [ "git", "add", "." ]);
+      assertGit(dir, stub, 1, [ "git", "diff-index", "--quiet", "HEAD", "--" ]);
+      assertGit(dir, stub, 2, [ "git", "commit", "-a", "-m", "Unipipe CLI: Some changes", "--author", "John Doe <john@doe.loc>"]);
       assertGit(dir, stub, 3, [ "git", "push" ]);
       assertSpyCalls(stub, 4);
 

--- a/cli/unipipe/commands/git.test.ts
+++ b/cli/unipipe/commands/git.test.ts
@@ -4,17 +4,43 @@ import { Repository } from "../repository.ts";
 import { commandPull, commandPush } from "./git.ts";
 
 Deno.test(
-  "can pull with fast forward",
+  "can pull with fast forward with no local changes",
   async () =>
     await withTempDir(async (tmp) => {
 
       const strub = createMockedGit([
+        successfulResult(),
+        successfulResult(),
         successfulResult()
       ]);
 
       await commandPull(new Repository(tmp));
 
-      assertSpyCall(strub, 0, {
+      assertSpyCall(strub, 0, { 
+        args: [{ 
+          cmd: [ 
+            "git",
+            "add",
+            "."
+          ], 
+          cwd: tmp 
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD",
+            "--"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
         args: [{
           cmd: [
             "git",
@@ -25,24 +51,61 @@ Deno.test(
         }]
       });
 
-      assertSpyCalls(strub, 1);      
+      assertSpyCalls(strub, 3);      
       strub.restore();      
     })
 );
 
 Deno.test(
-  "can pull with rebase",
+  "can pull with fast forward with local changes",
   async () =>
     await withTempDir(async (tmp) => {
 
       const strub = createMockedGit([
+        successfulResult(),
         failedResult(),
-        successfulResult()        
+        successfulResult(),
+        successfulResult(),
+        successfulResult()
       ]);
 
       await commandPull(new Repository(tmp));
 
-      assertSpyCall(strub, 0, {
+      assertSpyCall(strub, 0, { 
+        args: [{ 
+          cmd: [ 
+            "git",
+            "add",
+            "."
+          ], 
+          cwd: tmp 
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD",
+            "--"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "stash"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
         args: [{
           cmd: [
             "git",
@@ -53,7 +116,73 @@ Deno.test(
         }]
       });
 
+      assertSpyCall(strub, 4, {
+        args: [{
+          cmd: [
+            "git",
+            "stash",
+            "pop"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 5);      
+      strub.restore();      
+    })
+);
+
+Deno.test(
+  "can pull with rebase with no local chnages",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        successfulResult(),
+        failedResult(),
+        successfulResult(), 
+        successfulResult(),
+      ]);
+
+      await commandPull(new Repository(tmp));
+
+      assertSpyCall(strub, 0, { 
+        args: [{ 
+          cmd: [ 
+            "git",
+            "add",
+            "."
+          ], 
+          cwd: tmp 
+        }]
+      });
+
       assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD",
+            "--"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
         args: [{
           cmd: [
             "git",
@@ -64,7 +193,96 @@ Deno.test(
         }]
       });
 
-      assertSpyCalls(strub, 2);      
+      assertSpyCalls(strub, 4);      
+      strub.restore();      
+    })
+);
+
+Deno.test(
+  "can pull with rebase with local chnages",
+  async () =>
+    await withTempDir(async (tmp) => {
+
+      const strub = createMockedGit([
+        successfulResult(),
+        failedResult(),
+        successfulResult(),
+        failedResult(),
+        successfulResult(), 
+        successfulResult(),
+        successfulResult()
+      ]);
+
+      await commandPull(new Repository(tmp));
+
+      assertSpyCall(strub, 0, { 
+        args: [{ 
+          cmd: [ 
+            "git",
+            "add",
+            "."
+          ], 
+          cwd: tmp 
+        }]
+      });
+
+      assertSpyCall(strub, 1, {
+        args: [{
+          cmd: [
+            "git",
+            "diff-index",
+            "--quiet",
+            "HEAD",
+            "--"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 2, {
+        args: [{
+          cmd: [
+            "git",
+            "stash"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 3, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--ff-only"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 4, {
+        args: [{
+          cmd: [
+            "git",
+            "pull",
+            "--rebase"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCall(strub, 5, {
+        args: [{
+          cmd: [
+            "git",
+            "stash",
+            "pop"
+          ],
+          cwd: tmp
+        }]
+      });
+
+      assertSpyCalls(strub, 6);      
       strub.restore();      
     })
 );
@@ -125,7 +343,8 @@ Deno.test(
             "git",
             "diff-index",
             "--quiet",
-            "HEAD"
+            "HEAD",
+            "--"
           ],
           cwd: tmp
         }]
@@ -167,7 +386,8 @@ Deno.test(
             "git",
             "diff-index",
             "--quiet",
-            "HEAD"
+            "HEAD",
+            "--"
           ],
           cwd: tmp
         }]
@@ -236,7 +456,8 @@ Deno.test(
             "git",
             "diff-index",
             "--quiet",
-            "HEAD"
+            "HEAD",
+            "--"
           ],
           cwd: tmp
         }]
@@ -327,7 +548,8 @@ Deno.test(
             "git",
             "diff-index",
             "--quiet",
-            "HEAD"
+            "HEAD",
+            "--"
           ],
           cwd: tmp
         }]

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -41,19 +41,19 @@ export function registerGitCmd(program: Command) {
 }
 
 export async function commandPull(repo: Repository) {
-  const add = await gitAdd(repo.path);
-  if (!add) return;
+  const addSuccessful = await gitAdd(repo.path);
+  if (!addSuccessful) return;
 
   const hasChanges = await gitHasChanges(repo.path);
 
   if(hasChanges) {
-    const stash = await gitStash(repo.path);
-    if (!stash) return;
+    const stashSuccessful = await gitStash(repo.path);
+    if (!stashSuccessful) return;
   }
 
-  const pullFastForward = await gitPullFastForward(repo.path);
+  const pullSuccessful = await gitPullFastForward(repo.path);
 
-  if (!pullFastForward) {
+  if (!pullSuccessful) {
     await gitPullRebase(repo.path);
   }
 
@@ -63,24 +63,24 @@ export async function commandPull(repo: Repository) {
 }
 
 export async function commandPush(repo: Repository, opts: GitOpts) {
-  const name = opts.name || "Uncoipipe CLI";
+  const name = opts.name || "Unipipe CLI";
   const email = opts.email || "unipipe-cli@meshcloud.io";
   const message = opts.message || "Commit changes";
   
-  const add = await gitAdd(repo.path);
-  if (!add) return;
+  const addSuccessful = await gitAdd(repo.path);
+  if (!addSuccessful) return;
 
   const hasChanges = await gitHasChanges(repo.path);
 
   if (hasChanges) {
-    const commit = await gitCommit(repo.path, name, email, message);
-    if (!commit) return;
+    const commitSuccessful = await gitCommit(repo.path, name, email, message);
+    if (!commitSuccessful) return;
 
-    const push = await gitPush(repo.path);
-    if (!push) {
-      const pullFastForward = await gitPullFastForward(repo.path);
+    const pushSuccessful = await gitPush(repo.path);
+    if (!pushSuccessful) {
+      const pullSuccessful = await gitPullFastForward(repo.path);
 
-      if (!pullFastForward) {
+      if (!pullSuccessful) {
         await gitPullRebase(repo.path);
       }
       
@@ -88,7 +88,7 @@ export async function commandPush(repo: Repository, opts: GitOpts) {
     }
   }
   else {
-    console.log("No chnages to commit")
+    console.log("No changes to commit")
   }  
 }
 

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -2,9 +2,9 @@ import { Command } from "../deps.ts";
 import { Repository } from "../repository.ts";
 
 interface GitOpts {
-  name: string;
-  email: string;
-  message: string;
+  name?: string;
+  email?: string;
+  message?: string;
 }
 
 export function registerGitCmd(program: Command) {
@@ -14,9 +14,6 @@ export function registerGitCmd(program: Command) {
     .action(async (opts: GitOpts, cmd: string, repo: string | undefined) => {
 
       const repository = new Repository(repo ? repo : ".");
-      opts.name = opts.name || "Unipipe CLI";
-      opts.email = opts.email || "unipipe-cli@meshcloud.io";
-      opts.message = opts.message || "Commit changes";
 
       switch (cmd) {
         case "pull":
@@ -39,14 +36,18 @@ export async function commandPull(repo: Repository) {
   }
 }
 
-async function commandPush(repo: Repository, opts: GitOpts) {
+export async function commandPush(repo: Repository, opts: GitOpts) {
+  const name = opts.name || "Uncoipipe CLI";
+  const email = opts.email || "unipipe-cli@meshcloud.io";
+  const message = opts.message || "Commit changes";
+  
   const add = await gitAdd(repo.path);
   if (!add) return;
 
   const hasChanges = await gitDiffIndex(repo.path);
 
   if (!hasChanges) {
-    const commit = await gitCommit(repo.path, opts.name, opts.email, opts.message);
+    const commit = await gitCommit(repo.path, name, email, message);
     if (!commit) return;
   }
 

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -31,7 +31,7 @@ export function registerGitCmd(program: Command) {
     });
 }
 
-async function commandPull(repo: Repository) {
+export async function commandPull(repo: Repository) {
   const pullFastForward = await gitPullFastForward(repo.path);
 
   if (!pullFastForward) {

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -1,0 +1,41 @@
+import { Command } from "../deps.ts";
+import { Repository } from "../repository.ts";
+import ProcessStatus = Deno.ProcessStatus;
+
+interface GitOpts {
+}
+
+export function registerGitCmd(program: Command) {
+  program
+    .command("git <cmd> [repo]")
+    .description("Runs Git and simplifies working with pull/push commands")
+    .action(async (options: GitOpts, cmd: string, repo: string | undefined) => {
+
+      const repository = new Repository(repo ? repo : ".");
+
+      switch (cmd) {
+        case "pull":
+          await pull(repository, options);
+          break;
+      }
+    });
+}
+
+export async function pull(repo: Repository, opts: GitOpts): Promise<boolean> {
+  const status = await executeGit(repo.path, ["pull", "--ff-only"])
+
+  return status.success
+}
+
+export async function executeGit(dir: string, args: string[]): Promise<ProcessStatus> {
+  const cmd = ["git", ...args]
+
+  console.log(`Running ${cmd.join(' ')}`)
+
+  const process = Deno.run({
+    cmd: cmd,
+    cwd: dir
+  });
+
+  return await process.status();
+}

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -1,7 +1,7 @@
 import { Command } from "../deps.ts";
 import { Repository } from "../repository.ts";
 
-interface GitOpts {
+export interface GitOpts {
   name?: string;
   email?: string;
   message?: string;

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -10,7 +10,19 @@ interface GitOpts {
 export function registerGitCmd(program: Command) {
   program
     .command("git <cmd> [repo]")
-    .description("Runs Git to simplify pull/push commands")
+    .option(
+      "-n, --name [name:string]",
+      "Git author username. Default is `Unipipe CLI`."
+    )
+    .option(
+      "-e, --email [email:string]",
+      "Git author email. Default is `unipipe-cli@meshcloud.io`."
+    )
+    .option(
+      "-m, --message [message:string]",
+      "Commit message. Default is `Commit changes`."
+    )
+    .description("Runs Git pull/push commands resiliently. It takes care of retrying and rebasing if needed to make sure a push will be successful.")
     .action(async (opts: GitOpts, cmd: string, repo: string | undefined) => {
 
       const repository = new Repository(repo ? repo : ".");

--- a/cli/unipipe/commands/git.ts
+++ b/cli/unipipe/commands/git.ts
@@ -78,7 +78,12 @@ export async function commandPush(repo: Repository, opts: GitOpts) {
 
     const push = await gitPush(repo.path);
     if (!push) {
-      await commandPull(repo);
+      const pullFastForward = await gitPullFastForward(repo.path);
+
+      if (!pullFastForward) {
+        await gitPullRebase(repo.path);
+      }
+      
       await gitPush(repo.path);
     }
   }

--- a/cli/unipipe/main.ts
+++ b/cli/unipipe/main.ts
@@ -1,5 +1,6 @@
 import { registerBrowseCmd } from "./commands/browse.ts";
 import { registerGenerateCmd } from "./commands/generate.ts";
+import { registerGitCmd } from "./commands/git.ts";
 import { registerListCmd } from "./commands/list.ts";
 import { registerShowCmd } from "./commands/show.ts";
 import { registerTerraformCmd } from "./commands/terraform.ts";
@@ -24,6 +25,7 @@ registerGenerateCmd(program);
 registerUpgradeCmd(program);
 registerBrowseCmd(program);
 registerTerraformCmd(program);
+registerGitCmd(program);
 
 const hasArgs = Deno.args.length > 0;
 if (hasArgs) {

--- a/terraform-runner/run-unipipe-terraform.sh
+++ b/terraform-runner/run-unipipe-terraform.sh
@@ -21,4 +21,4 @@ cd $REPO_DIR
 
 /usr/local/bin/unipipe git pull $REPO_DIR
 /usr/local/bin/unipipe terraform $REPO_DIR
-/usr/local/bin/unipipe git push $REPO_DIR
+/usr/local/bin/unipipe git push $REPO_DIR -m "processed instances via unipipe terraform"

--- a/terraform-runner/run-unipipe-terraform.sh
+++ b/terraform-runner/run-unipipe-terraform.sh
@@ -18,10 +18,7 @@ if [[ ! -d "$REPO_DIR" ]]; then
 fi
 
 cd $REPO_DIR
-git pull
 
+/usr/local/bin/unipipe git pull $REPO_DIR
 /usr/local/bin/unipipe terraform $REPO_DIR
-
-git add .
-git commit -m "processed instances via unipipe terraform"
-git push origin
+/usr/local/bin/unipipe git push $REPO_DIR


### PR DESCRIPTION
Add support of Git into Unipipe CLI

New command
git {cmd} {repo}

Parameters
- {cmd} required parameter to specify Git operation. Possible values 'pull' or 'push'
- {repo} optional parameter to specify Git repository path. The current directory is used if a parameter is empty

Commands
- 'pull' does a pull with fast forward merge
- 'push' adds changes into a staged area, makes a commit, and pushes it to a remote repository

Examples
- unipipe git pull /some/repo/path
- unipipe git push /some/repo/path