### PR TITLE
fix: Fix getServiceInstanceBinding not found handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - no changes
 
 ### OSB
-- no changes
+- fix getServiceInstanceBinding endpoint to return a 404, if binding does not exist
 
 ### Terraform Runner
 - update terraform to v1.3.7

--- a/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.kt
@@ -3,6 +3,7 @@ package io.meshcloud.dockerosb.service
 import io.meshcloud.dockerosb.model.ServiceBinding
 import io.meshcloud.dockerosb.persistence.GitOperationContextFactory
 import org.springframework.cloud.servicebroker.exception.ServiceBrokerAsyncRequiredException
+import org.springframework.cloud.servicebroker.exception.ServiceInstanceBindingDoesNotExistException
 import org.springframework.cloud.servicebroker.model.binding.*
 import org.springframework.cloud.servicebroker.service.ServiceInstanceBindingService
 import org.springframework.stereotype.Service
@@ -15,7 +16,7 @@ class GenericServiceInstanceBindingService(
 
 
   override fun createServiceInstanceBinding(request: CreateServiceInstanceBindingRequest): Mono<CreateServiceInstanceBindingResponse> {
-    if (!request.isAsyncAccepted){
+    if (!request.isAsyncAccepted) {
       throw ServiceBrokerAsyncRequiredException("UniPipe service broker invokes async CI/CD pipelines")
     }
 
@@ -47,7 +48,7 @@ class GenericServiceInstanceBindingService(
                 .build()
         )
 
-      if (!request.isAsyncAccepted){
+      if (!request.isAsyncAccepted) {
         throw ServiceBrokerAsyncRequiredException("UniPipe service broker invokes async CI/CD pipelines")
       }
 
@@ -84,6 +85,9 @@ class GenericServiceInstanceBindingService(
       context.attemptToRefreshRemoteChanges()
 
       val repository = context.buildServiceInstanceBindingRepository()
+
+      repository.tryGetServiceBinding(request.serviceInstanceId, request.bindingId)
+          ?: throw ServiceInstanceBindingDoesNotExistException(request.bindingId)
 
       val credentials = repository.getServiceBindingCredentials(request.serviceInstanceId, request.bindingId)
 

--- a/src/test/kotlin/io/meshcloud/dockerosb/TestDataBuilder.kt
+++ b/src/test/kotlin/io/meshcloud/dockerosb/TestDataBuilder.kt
@@ -5,6 +5,8 @@ import io.meshcloud.dockerosb.persistence.YamlHandler
 import org.springframework.cloud.servicebroker.model.PlatformContext
 import org.springframework.cloud.servicebroker.model.binding.CreateServiceInstanceBindingRequest
 import org.springframework.cloud.servicebroker.model.binding.DeleteServiceInstanceBindingRequest
+import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingRequest
+import org.springframework.cloud.servicebroker.model.binding.GetServiceInstanceBindingRequest.GetServiceInstanceBindingRequestBuilder
 import org.springframework.cloud.servicebroker.model.instance.CreateServiceInstanceRequest
 import org.springframework.cloud.servicebroker.model.instance.UpdateServiceInstanceRequest
 import java.io.File
@@ -96,6 +98,21 @@ class TestDataBuilder(catalogPath: String, yamlHandler: YamlHandler) {
         .originatingIdentity(originatingIdentity)
         .asyncAccepted(true)
         .bindingId(bindingId)
+        .also {
+          customize?.invoke(it)
+        }
+        .build()
+  }
+
+  fun getServiceInstanceBindingRequest(
+      instanceId: String,
+      bindingId: String,
+      customize: (GetServiceInstanceBindingRequestBuilder.() -> Unit)? = null
+  ): GetServiceInstanceBindingRequest {
+    return GetServiceInstanceBindingRequest.builder()
+        .serviceInstanceId(instanceId)
+        .bindingId(bindingId)
+        .originatingIdentity(originatingIdentity)
         .also {
           customize?.invoke(it)
         }


### PR DESCRIPTION
Previously the SB always returned a 200 at the getServiceInstanceBinding, even if the binding does not exist. This is fixed now.