### PR TITLE
Added status update for to be updated instances

### DIFF
--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/ServiceInstanceRepository.kt
@@ -44,6 +44,14 @@ class ServiceInstanceRepository(private val yamlHandler: YamlHandler, private va
       objectToWrite = serviceInstance,
       file = instanceYml
     )
+
+    val statusYml = serviceInstanceStatusYmlFile(serviceInstanceId)
+    val status = Status("in progress", "service update")
+    yamlHandler.writeObject(
+        objectToWrite = status,
+        file = statusYml
+    )
+
     gitHandler.commitAllChanges(
       commitMessage = "Updated Service instance $serviceInstanceId"
     )


### PR DESCRIPTION
ServiceInstanceReopistory is not updating/invalidating the status of instances. The open [issue](https://github.com/meshcloud/unipipe-service-broker/issues/22) describes what we were facing when trying to update a successfully created instance. The status of the update will not be provided to the marketplace because the successful state is taken out of the present status.yml.

When just putting the status of the to be updated instance to "in progress", the pipeline can do its job (especially overwrite the status.yml file at the end) and the broker will report the correct status to the marketplace. 

Since the instance.yml file is already being updated by the broker, updating the status.yml file does no harm.