### PR TITLE
Set credentials provider for fetchMergePush

### DIFF
--- a/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/persistence/GitHandlerService.kt
@@ -121,7 +121,13 @@ open class GitHandlerService(
   private fun fetchMergePush(): Boolean {
     // fetch from the remote
     git.fetch()
-        .apply { remote = "origin" }
+        .apply {              
+          remote = "origin" 
+
+          gitConfig.username?.let {
+            setCredentialsProvider(UsernamePasswordCredentialsProvider(gitConfig.username, gitConfig.password))
+          }
+        }
         .call()
 
     // merge changes - this happens locally in our repository


### PR DESCRIPTION
When using Git over HTTP(s) for the remote Git repo, there was no credential provider for the `fetchMergePush` function. Thus those operations would fail for repositories requiring authentication. See the log output:
```
broker-1  | org.eclipse.jgit.api.errors.TransportException: https://xxx: Authentication is required but no CredentialsProvider has been registered
broker-1  |     at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:249) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitHandlerService.fetchMergePush(GitHandlerService.kt:125) ~[classes!/:na]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitHandlerService.synchronizeWithRemoteRepository(GitHandlerService.kt:113) ~[classes!/:na]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitOperationContext.synchronizeWithRemoteRepository(GitOperationContext.kt:39) ~[classes!/:na]
broker-1  |     at io.meshcloud.dockerosb.persistence.ScheduledPushHandler.pushTask(ScheduledPushHandler.kt:38) ~[classes!/:na]
broker-1  |     at jdk.internal.reflect.GeneratedMethodAccessor20.invoke(Unknown Source) ~[na:na]
broker-1  |     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
broker-1  |     at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84) ~[spring-context-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-5.3.30.jar!/:5.3.30]
broker-1  |     at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.lang.Thread.run(Unknown Source) ~[na:na]
broker-1  | Caused by: org.eclipse.jgit.errors.TransportException: https://xxx: Authentication is required but no CredentialsProvider has been registered
broker-1  |     at org.eclipse.jgit.transport.TransportHttp.connect(TransportHttp.java:687) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.TransportHttp.openFetch(TransportHttp.java:465) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:153) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:105) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.Transport.fetch(Transport.java:1480) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:238) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     ... 15 common frames omitted
```

This PR fixes this.