### PR TITLE
Create tmp dir for SSH key

### DIFF
--- a/src/main/kotlin/io/meshcloud/dockerosb/config/CustomSshSessionFactory.kt
+++ b/src/main/kotlin/io/meshcloud/dockerosb/config/CustomSshSessionFactory.kt
@@ -8,6 +8,8 @@ import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig
 import org.eclipse.jgit.util.FS
 import org.eclipse.jgit.util.FileUtils
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Paths
 
 class CustomSshSessionFactory(
     private val sshKey: String
@@ -34,7 +36,9 @@ class CustomSshSessionFactory(
     val content = sshKey.substring(contentStartIndex, contentEndIndex).replace(" ", "\n")
     val formattedKey = sshKey.substring(0, contentStartIndex) + content + sshKey.substring(contentEndIndex, sshKey.length - 1)
 
-    File(keyPath).writeText(formattedKey)
+    val keyFile = File(keyPath)
+    Files.createDirectories(Paths.get(keyFile.parent))
+    keyFile.writeText(formattedKey)
 
     val jsch = super.getJSch(hc, fs)
     jsch.removeAllIdentity()


### PR DESCRIPTION
When using SSH keys for authentication against the remote git repo, the container could not start, as the application wasn't able to write the SSH key to the designated directory. See the logs output:

<details>

<summary>Logs for failing app start</summary>

```
broker-1  | Application is running as root (UID 0). This is considered insecure.
broker-1  | 
broker-1  |   .   ____          _            __ _ _
broker-1  |  /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
broker-1  | ( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
broker-1  |  \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
broker-1  |   '  |____| .__|_| |_|_| |_\__, | / / / /
broker-1  |  =========|_|==============|___/=/_/_/_/
broker-1  |  :: Spring Boot ::               (v2.7.16)
broker-1  | 
broker-1  | 2024-08-30 14:10:11.893  INFO 81 --- [           main] i.m.dockerosb.DockerOsbApplicationKt     : Starting DockerOsbApplicationKt using Java 17.0.12 on 303b7a5ef6b9 with PID 81 (/app/unipipe-service-broker-1.0.0.jar started by root in /app)
broker-1  | 2024-08-30 14:10:11.899  INFO 81 --- [           main] i.m.dockerosb.DockerOsbApplicationKt     : No active profile set, falling back to 1 default profile: "default"
broker-1  | 2024-08-30 14:10:14.472  INFO 81 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8075 (http)
broker-1  | 2024-08-30 14:10:14.489  INFO 81 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
broker-1  | 2024-08-30 14:10:14.489  INFO 81 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.80]
broker-1  | 2024-08-30 14:10:14.621  INFO 81 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
broker-1  | 2024-08-30 14:10:14.621  INFO 81 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 2602 ms
broker-1  | 2024-08-30 14:10:18.397  WARN 81 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'genericServiceInstanceBindingService' defined in URL [jar:file:/app/unipipe-service-broker-1.0.0.jar!/BOOT-INF/classes!/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'gitOperationContextFactory' defined in URL [jar:file:/app/unipipe-service-broker-1.0.0.jar!/BOOT-INF/classes!/io/meshcloud/dockerosb/persistence/GitOperationContextFactory.class]: Bean instantiation via constructor failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.meshcloud.dockerosb.persistence.GitOperationContextFactory]: Constructor threw exception; nested exception is org.eclipse.jgit.api.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  | 2024-08-30 14:10:18.402  INFO 81 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
broker-1  | 2024-08-30 14:10:18.423  INFO 81 --- [           main] ConditionEvaluationReportLoggingListener : 
broker-1  | 
broker-1  | Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
broker-1  | 2024-08-30 14:10:18.458 ERROR 81 --- [           main] o.s.boot.SpringApplication               : Application run failed
broker-1  | 
broker-1  | org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'genericServiceInstanceBindingService' defined in URL [jar:file:/app/unipipe-service-broker-1.0.0.jar!/BOOT-INF/classes!/io/meshcloud/dockerosb/service/GenericServiceInstanceBindingService.class]: Unsatisfied dependency expressed through constructor parameter 0; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'gitOperationContextFactory' defined in URL [jar:file:/app/unipipe-service-broker-1.0.0.jar!/BOOT-INF/classes!/io/meshcloud/dockerosb/persistence/GitOperationContextFactory.class]: Bean instantiation via constructor failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.meshcloud.dockerosb.persistence.GitOperationContextFactory]: Constructor threw exception; nested exception is org.eclipse.jgit.api.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:801) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:224) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1372) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1222) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:955) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:921) ~[spring-context-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583) ~[spring-context-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:147) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:731) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:408) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at org.springframework.boot.SpringApplication.run(SpringApplication.java:307) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at org.springframework.boot.SpringApplication.run(SpringApplication.java:1303) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at org.springframework.boot.SpringApplication.run(SpringApplication.java:1292) ~[spring-boot-2.7.16.jar!/:2.7.16]
broker-1  |     at io.meshcloud.dockerosb.DockerOsbApplicationKt.main(DockerOsbApplication.kt:15) ~[classes!/:na]
broker-1  |     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
broker-1  |     at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
broker-1  |     at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[na:na]
broker-1  |     at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49) ~[unipipe-service-broker-1.0.0.jar:na]
broker-1  |     at org.springframework.boot.loader.Launcher.launch(Launcher.java:108) ~[unipipe-service-broker-1.0.0.jar:na]
broker-1  |     at org.springframework.boot.loader.Launcher.launch(Launcher.java:58) ~[unipipe-service-broker-1.0.0.jar:na]
broker-1  |     at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:65) ~[unipipe-service-broker-1.0.0.jar:na]
broker-1  | Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'gitOperationContextFactory' defined in URL [jar:file:/app/unipipe-service-broker-1.0.0.jar!/BOOT-INF/classes!/io/meshcloud/dockerosb/persistence/GitOperationContextFactory.class]: Bean instantiation via constructor failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.meshcloud.dockerosb.persistence.GitOperationContextFactory]: Constructor threw exception; nested exception is org.eclipse.jgit.api.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:310) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:291) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1372) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1222) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:582) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:276) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1391) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1311) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:911) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:788) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     ... 27 common frames omitted
broker-1  | Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.meshcloud.dockerosb.persistence.GitOperationContextFactory]: Constructor threw exception; nested exception is org.eclipse.jgit.api.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  |     at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:224) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:117) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:306) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     ... 41 common frames omitted
broker-1  | Caused by: org.eclipse.jgit.api.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  |     at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:249) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitHandlerService$Companion.initGit(GitHandlerService.kt:304) ~[classes!/:na]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitHandlerService.<init>(GitHandlerService.kt:25) ~[classes!/:na]
broker-1  |     at io.meshcloud.dockerosb.persistence.GitOperationContextFactory.<init>(GitOperationContextFactory.kt:21) ~[classes!/:na]
broker-1  |     at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[na:na]
broker-1  |     at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(Unknown Source) ~[na:na]
broker-1  |     at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.lang.reflect.Constructor.newInstance(Unknown Source) ~[na:na]
broker-1  |     at kotlin.reflect.jvm.internal.calls.CallerImpl$Constructor.call(CallerImpl.kt:41) ~[kotlin-reflect-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108) ~[kotlin-reflect-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at kotlin.reflect.jvm.internal.KCallableImpl.callDefaultMethod$kotlin_reflection(KCallableImpl.kt:159) ~[kotlin-reflect-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at kotlin.reflect.jvm.internal.KCallableImpl.callBy(KCallableImpl.kt:112) ~[kotlin-reflect-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at org.springframework.beans.BeanUtils$KotlinDelegate.instantiateClass(BeanUtils.java:893) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:196) ~[spring-beans-5.3.30.jar!/:5.3.30]
broker-1  |     ... 43 common frames omitted
broker-1  | Caused by: org.eclipse.jgit.errors.TransportException: git@ssh.dev.azure.com:xxx: remote hung up unexpectedly
broker-1  |     at org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:311) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.TransportGitSsh.openFetch(TransportGitSsh.java:152) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.FetchProcess.executeImp(FetchProcess.java:153) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.FetchProcess.execute(FetchProcess.java:105) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.Transport.fetch(Transport.java:1480) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.api.FetchCommand.call(FetchCommand.java:238) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     ... 57 common frames omitted
broker-1  | Caused by: java.io.FileNotFoundException: tmp/ssh_key (No such file or directory)
broker-1  |     at java.base/java.io.FileOutputStream.open0(Native Method) ~[na:na]
broker-1  |     at java.base/java.io.FileOutputStream.open(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.io.FileOutputStream.<init>(Unknown Source) ~[na:na]
broker-1  |     at java.base/java.io.FileOutputStream.<init>(Unknown Source) ~[na:na]
broker-1  |     at kotlin.io.FilesKt__FileReadWriteKt.writeBytes(FileReadWrite.kt:108) ~[kotlin-stdlib-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at kotlin.io.FilesKt__FileReadWriteKt.writeText(FileReadWrite.kt:134) ~[kotlin-stdlib-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at kotlin.io.FilesKt__FileReadWriteKt.writeText$default(FileReadWrite.kt:134) ~[kotlin-stdlib-1.7.10.jar!/:1.7.10-release-333(1.7.10)]
broker-1  |     at io.meshcloud.dockerosb.config.CustomSshSessionFactory.getJSch(CustomSshSessionFactory.kt:37) ~[classes!/:na]
broker-1  |     at org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory.createSession(JschConfigSessionFactory.java:344) ~[org.eclipse.jgit.ssh.jsch-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory.createSession(JschConfigSessionFactory.java:211) ~[org.eclipse.jgit.ssh.jsch-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory.getSession(JschConfigSessionFactory.java:115) ~[org.eclipse.jgit.ssh.jsch-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.SshTransport.getSession(SshTransport.java:107) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     at org.eclipse.jgit.transport.TransportGitSsh$SshFetchConnection.<init>(TransportGitSsh.java:279) ~[org.eclipse.jgit-6.10.0.202406032230-r.jar!/:6.10.0.202406032230-r]
broker-1  |     ... 62 common frames omitted
```

</details>

With this PR, the directory will be created prior writing the key file.